### PR TITLE
fix: sync radio button state with DOM on mount to handle browser back navigation

### DIFF
--- a/components/Selector.tsx
+++ b/components/Selector.tsx
@@ -17,18 +17,22 @@ const Selector = ({ initialState, onChange }: SelectorProps) => {
 
   // Sync React state with DOM state on mount (handles browser back navigation)
   useEffect(() => {
-    const professionalRadio = document.getElementById("professional") as HTMLInputElement;
-    const personalRadio = document.getElementById("personal") as HTMLInputElement;
-    
+    const professionalRadio = document.getElementById(
+      "professional",
+    ) as HTMLInputElement;
+    const personalRadio = document.getElementById(
+      "personal",
+    ) as HTMLInputElement;
+
     if (professionalRadio && personalRadio) {
       let actualState = initialState;
-      
+
       if (professionalRadio.checked) {
         actualState = BioState.Professional;
       } else if (personalRadio.checked) {
         actualState = BioState.Personal;
       }
-      
+
       if (actualState !== state) {
         setState(actualState);
         onChange(actualState);


### PR DESCRIPTION
Fixes issue where radio buttons on about page lose state synchronization when returned to via browser back button.

## Changes
- Added useEffect hook to sync React state with DOM state on mount
- Fixed typo in function name (hangleChange → handleChange)

## Testing
1. Navigate to `/about` page
2. Click "Personal" radio button
3. Navigate to another site (e.g., google.com)
4. Press browser back button
5. Verify that both radio button selection AND content match

Fixes #376

Generated with [Claude Code](https://claude.ai/code)