### PR TITLE
Add subtle line-art background with personal interest motifs

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -253,9 +253,37 @@
 
 
 @layer components {
-  
+
   .transform-minus-half {
     transform: translate(-50%, -50%);
+  }
+
+  /* Line Art Background */
+  .line-art-background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 0;
+    overflow: hidden;
+  }
+
+  .line-art-icon-wrapper {
+    position: absolute;
+  }
+
+  .line-art-icon {
+    width: 100%;
+    height: 100%;
+    color: var(--primary);
+    opacity: 0.06;
+  }
+
+  /* Slightly higher opacity for dark mode */
+  :root[data-theme="dark"] .line-art-icon {
+    opacity: 0.08;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -272,6 +272,8 @@
 
   .line-art-icon-wrapper {
     position: absolute;
+    pointer-events: auto;
+    cursor: default;
   }
 
   .line-art-icon {
@@ -279,11 +281,144 @@
     height: 100%;
     color: var(--primary);
     opacity: 0.12;
+    transition: opacity 0.3s ease;
+  }
+
+  .line-art-icon-wrapper:hover .line-art-icon {
+    opacity: 0.25;
   }
 
   /* Slightly higher opacity for dark mode */
   :root[data-theme="dark"] .line-art-icon {
     opacity: 0.15;
+  }
+
+  :root[data-theme="dark"] .line-art-icon-wrapper:hover .line-art-icon {
+    opacity: 0.3;
+  }
+
+  /* ===== HOVER ANIMATIONS ===== */
+
+  /* Coffee steam - floats up with wiggle */
+  @keyframes steam-rise {
+    0%, 100% { transform: translateY(0) translateX(0); opacity: 1; }
+    25% { transform: translateY(-2px) translateX(1px); }
+    50% { transform: translateY(-4px) translateX(-1px); opacity: 0.7; }
+    75% { transform: translateY(-2px) translateX(1px); }
+  }
+
+  .line-art-icon-wrapper:hover .line-art-steam {
+    animation: steam-rise 1s ease-in-out infinite;
+  }
+
+  /* Camera shutter - pulse/click effect */
+  @keyframes shutter-click {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(0.7); }
+  }
+
+  .line-art-icon-wrapper:hover .line-art-shutter {
+    animation: shutter-click 0.3s ease-in-out;
+  }
+
+  /* Dumbbell pump - up and down */
+  @keyframes pump {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-3px); }
+  }
+
+  .line-art-icon-wrapper:hover .line-art-pump {
+    animation: pump 0.5s ease-in-out infinite;
+  }
+
+  /* Fishing line wobble */
+  @keyframes line-wobble {
+    0%, 100% { transform: translateX(0); }
+    25% { transform: translateX(2px); }
+    75% { transform: translateX(-2px); }
+  }
+
+  .line-art-icon-wrapper:hover .line-art-fishing-line {
+    animation: line-wobble 0.8s ease-in-out infinite;
+  }
+
+  /* Fish swimming */
+  @keyframes fish-swim {
+    0%, 100% { transform: translateX(0) rotate(0deg); }
+    25% { transform: translateX(1px) rotate(2deg); }
+    75% { transform: translateX(-1px) rotate(-2deg); }
+  }
+
+  .line-art-icon-wrapper:hover .line-art-fish {
+    animation: fish-swim 0.6s ease-in-out infinite;
+  }
+
+  /* Code cursor blink */
+  @keyframes cursor-blink {
+    0%, 50%, 100% { opacity: 1; }
+    25%, 75% { opacity: 0; }
+  }
+
+  .line-art-icon-wrapper:hover .line-art-cursor {
+    animation: cursor-blink 1s step-end infinite;
+  }
+
+  /* Electronics pulse */
+  @keyframes electric-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.5; transform: scale(1.3); }
+  }
+
+  .line-art-icon-wrapper:hover .line-art-pulse {
+    animation: electric-pulse 0.4s ease-in-out infinite;
+  }
+
+  /* Circuit trace */
+  @keyframes circuit-flow {
+    0% { stroke-dasharray: 0 100; }
+    100% { stroke-dasharray: 100 0; }
+  }
+
+  .line-art-icon-wrapper:hover .line-art-circuit {
+    stroke-dasharray: 4 2;
+    animation: circuit-flow 1s linear infinite;
+  }
+
+  /* 3D Printer head movement */
+  @keyframes printhead-move {
+    0%, 100% { transform: translateX(0); }
+    50% { transform: translateX(4px); }
+  }
+
+  .line-art-icon-wrapper:hover .line-art-printhead {
+    animation: printhead-move 0.8s ease-in-out infinite;
+  }
+
+  /* Airplane fly/tilt */
+  @keyframes fly-tilt {
+    0%, 100% { transform: translateY(0) rotate(0deg); }
+    25% { transform: translateY(-2px) rotate(-2deg); }
+    75% { transform: translateY(2px) rotate(2deg); }
+  }
+
+  .line-art-icon-wrapper:hover .line-art-fly {
+    animation: fly-tilt 1.2s ease-in-out infinite;
+  }
+
+  /* Motorcycle wheel spin */
+  @keyframes wheel-spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+
+  .line-art-icon-wrapper:hover .line-art-wheel-back {
+    transform-origin: 10px 34px;
+    animation: wheel-spin 0.8s linear infinite;
+  }
+
+  .line-art-icon-wrapper:hover .line-art-wheel-front {
+    transform-origin: 40px 34px;
+    animation: wheel-spin 0.6s linear infinite;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -282,6 +282,11 @@
     color: var(--primary);
     opacity: 0.12;
     transition: opacity 0.3s ease;
+    pointer-events: auto;
+  }
+
+  .line-art-icon * {
+    pointer-events: auto;
   }
 
   .line-art-icon-wrapper:hover .line-art-icon {
@@ -412,12 +417,12 @@
   }
 
   .line-art-icon-wrapper:hover .line-art-wheel-back {
-    transform-origin: 10px 34px;
+    transform-origin: 10px 32px;
     animation: wheel-spin 0.8s linear infinite;
   }
 
   .line-art-icon-wrapper:hover .line-art-wheel-front {
-    transform-origin: 40px 34px;
+    transform-origin: 38px 32px;
     animation: wheel-spin 0.6s linear infinite;
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -278,12 +278,12 @@
     width: 100%;
     height: 100%;
     color: var(--primary);
-    opacity: 0.06;
+    opacity: 0.12;
   }
 
   /* Slightly higher opacity for dark mode */
   :root[data-theme="dark"] .line-art-icon {
-    opacity: 0.08;
+    opacity: 0.15;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from "react";
 import { Analytics } from "@vercel/analytics/react";
 import { ThemeProviderWrapper } from "@/components/Theme/ThemeProvider";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import { LineArtBackground } from "@/components/LineArtBackground";
 
 export const metadata: Metadata = {
   title: "kylejs",
@@ -55,6 +56,7 @@ export default async function RootLayout({
         />
       </head>
       <body>
+        <LineArtBackground />
         <ThemeProviderWrapper>{children}</ThemeProviderWrapper>
         <SpeedInsights />
       </body>

--- a/components/LineArtBackground/LineArtBackground.tsx
+++ b/components/LineArtBackground/LineArtBackground.tsx
@@ -28,92 +28,143 @@ const icons = [
 
 // Predefined scattered placements for a natural, hand-placed feel
 // Coordinates are percentages, rotations in degrees
-// Denser layout with more icons
+// Dense layout with icons every ~10% vertically
 const placements = [
-  // Row 1 (y: 0-10)
-  { x: 2, y: 3, rotation: -12, size: 44, iconIndex: 0 },
-  { x: 14, y: 7, rotation: 22, size: 48, iconIndex: 7 },
-  { x: 28, y: 2, rotation: -8, size: 42, iconIndex: 4 },
-  { x: 42, y: 8, rotation: 15, size: 50, iconIndex: 2 },
-  { x: 56, y: 4, rotation: -18, size: 46, iconIndex: 5 },
-  { x: 70, y: 9, rotation: 10, size: 44, iconIndex: 1 },
-  { x: 84, y: 3, rotation: -5, size: 48, iconIndex: 8 },
-  { x: 96, y: 7, rotation: 20, size: 42, iconIndex: 3 },
+  // Row 1 (y: 0-6)
+  { x: 2, y: 2, rotation: -12, size: 44, iconIndex: 0 },
+  { x: 12, y: 5, rotation: 22, size: 46, iconIndex: 7 },
+  { x: 24, y: 3, rotation: -8, size: 42, iconIndex: 4 },
+  { x: 36, y: 6, rotation: 15, size: 48, iconIndex: 2 },
+  { x: 48, y: 2, rotation: -18, size: 44, iconIndex: 5 },
+  { x: 60, y: 5, rotation: 10, size: 46, iconIndex: 1 },
+  { x: 72, y: 3, rotation: -5, size: 42, iconIndex: 8 },
+  { x: 84, y: 6, rotation: 20, size: 48, iconIndex: 3 },
+  { x: 96, y: 4, rotation: -15, size: 44, iconIndex: 6 },
 
-  // Row 2 (y: 12-20)
-  { x: 6, y: 16, rotation: 8, size: 46, iconIndex: 5 },
-  { x: 20, y: 13, rotation: -15, size: 52, iconIndex: 3 },
-  { x: 34, y: 18, rotation: 25, size: 44, iconIndex: 8 },
-  { x: 48, y: 14, rotation: -10, size: 48, iconIndex: 6 },
-  { x: 62, y: 19, rotation: 12, size: 42, iconIndex: 0 },
-  { x: 76, y: 15, rotation: -22, size: 50, iconIndex: 4 },
-  { x: 90, y: 17, rotation: 5, size: 46, iconIndex: 1 },
+  // Row 2 (y: 8-14)
+  { x: 6, y: 11, rotation: 8, size: 46, iconIndex: 5 },
+  { x: 18, y: 9, rotation: -15, size: 50, iconIndex: 3 },
+  { x: 30, y: 13, rotation: 25, size: 44, iconIndex: 8 },
+  { x: 42, y: 10, rotation: -10, size: 48, iconIndex: 6 },
+  { x: 54, y: 14, rotation: 12, size: 42, iconIndex: 0 },
+  { x: 66, y: 11, rotation: -22, size: 46, iconIndex: 4 },
+  { x: 78, y: 9, rotation: 5, size: 50, iconIndex: 1 },
+  { x: 90, y: 13, rotation: -18, size: 44, iconIndex: 7 },
 
-  // Row 3 (y: 24-32)
-  { x: 3, y: 28, rotation: -18, size: 48, iconIndex: 1 },
-  { x: 16, y: 25, rotation: 15, size: 44, iconIndex: 2 },
-  { x: 30, y: 30, rotation: -8, size: 50, iconIndex: 7 },
-  { x: 44, y: 26, rotation: 20, size: 46, iconIndex: 0 },
-  { x: 58, y: 31, rotation: -12, size: 42, iconIndex: 5 },
-  { x: 72, y: 27, rotation: 8, size: 48, iconIndex: 3 },
-  { x: 86, y: 29, rotation: -20, size: 44, iconIndex: 6 },
-  { x: 98, y: 25, rotation: 12, size: 46, iconIndex: 8 },
+  // Row 3 (y: 16-22)
+  { x: 3, y: 19, rotation: -18, size: 48, iconIndex: 1 },
+  { x: 14, y: 17, rotation: 15, size: 44, iconIndex: 2 },
+  { x: 26, y: 21, rotation: -8, size: 46, iconIndex: 7 },
+  { x: 38, y: 18, rotation: 20, size: 50, iconIndex: 0 },
+  { x: 50, y: 22, rotation: -12, size: 42, iconIndex: 5 },
+  { x: 62, y: 19, rotation: 8, size: 48, iconIndex: 3 },
+  { x: 74, y: 17, rotation: -20, size: 44, iconIndex: 6 },
+  { x: 86, y: 21, rotation: 12, size: 46, iconIndex: 8 },
+  { x: 97, y: 18, rotation: -5, size: 42, iconIndex: 4 },
 
-  // Row 4 (y: 36-44)
-  { x: 8, y: 40, rotation: 10, size: 46, iconIndex: 4 },
-  { x: 22, y: 37, rotation: -15, size: 50, iconIndex: 8 },
-  { x: 36, y: 42, rotation: 22, size: 44, iconIndex: 5 },
-  { x: 50, y: 38, rotation: -5, size: 48, iconIndex: 3 },
-  { x: 64, y: 43, rotation: 18, size: 42, iconIndex: 6 },
-  { x: 78, y: 39, rotation: -25, size: 46, iconIndex: 1 },
-  { x: 92, y: 41, rotation: 8, size: 50, iconIndex: 2 },
+  // Row 4 (y: 24-30)
+  { x: 8, y: 27, rotation: 10, size: 46, iconIndex: 4 },
+  { x: 20, y: 25, rotation: -15, size: 48, iconIndex: 8 },
+  { x: 32, y: 29, rotation: 22, size: 44, iconIndex: 5 },
+  { x: 44, y: 26, rotation: -5, size: 50, iconIndex: 3 },
+  { x: 56, y: 30, rotation: 18, size: 42, iconIndex: 6 },
+  { x: 68, y: 27, rotation: -25, size: 46, iconIndex: 1 },
+  { x: 80, y: 25, rotation: 8, size: 48, iconIndex: 2 },
+  { x: 92, y: 29, rotation: -12, size: 44, iconIndex: 0 },
 
-  // Row 5 (y: 48-56)
-  { x: 1, y: 52, rotation: -10, size: 44, iconIndex: 6 },
-  { x: 14, y: 49, rotation: 20, size: 48, iconIndex: 0 },
-  { x: 28, y: 54, rotation: -18, size: 46, iconIndex: 2 },
-  { x: 42, y: 50, rotation: 12, size: 42, iconIndex: 7 },
-  { x: 56, y: 55, rotation: -8, size: 50, iconIndex: 4 },
-  { x: 70, y: 51, rotation: 15, size: 44, iconIndex: 8 },
-  { x: 84, y: 53, rotation: -22, size: 48, iconIndex: 5 },
-  { x: 97, y: 49, rotation: 5, size: 46, iconIndex: 3 },
+  // Row 5 (y: 32-38)
+  { x: 1, y: 35, rotation: -10, size: 44, iconIndex: 6 },
+  { x: 12, y: 33, rotation: 20, size: 48, iconIndex: 0 },
+  { x: 24, y: 37, rotation: -18, size: 46, iconIndex: 2 },
+  { x: 36, y: 34, rotation: 12, size: 42, iconIndex: 7 },
+  { x: 48, y: 38, rotation: -8, size: 50, iconIndex: 4 },
+  { x: 60, y: 35, rotation: 15, size: 44, iconIndex: 8 },
+  { x: 72, y: 33, rotation: -22, size: 48, iconIndex: 5 },
+  { x: 84, y: 37, rotation: 5, size: 46, iconIndex: 3 },
+  { x: 96, y: 34, rotation: -15, size: 42, iconIndex: 1 },
 
-  // Row 6 (y: 60-68)
-  { x: 5, y: 64, rotation: 18, size: 48, iconIndex: 3 },
-  { x: 19, y: 61, rotation: -12, size: 44, iconIndex: 1 },
-  { x: 33, y: 66, rotation: 8, size: 50, iconIndex: 6 },
-  { x: 47, y: 62, rotation: -20, size: 46, iconIndex: 5 },
-  { x: 61, y: 67, rotation: 25, size: 42, iconIndex: 0 },
-  { x: 75, y: 63, rotation: -5, size: 48, iconIndex: 2 },
-  { x: 89, y: 65, rotation: 15, size: 44, iconIndex: 7 },
+  // Row 6 (y: 40-46)
+  { x: 5, y: 43, rotation: 18, size: 48, iconIndex: 3 },
+  { x: 17, y: 41, rotation: -12, size: 44, iconIndex: 1 },
+  { x: 29, y: 45, rotation: 8, size: 50, iconIndex: 6 },
+  { x: 41, y: 42, rotation: -20, size: 46, iconIndex: 5 },
+  { x: 53, y: 46, rotation: 25, size: 42, iconIndex: 0 },
+  { x: 65, y: 43, rotation: -5, size: 48, iconIndex: 2 },
+  { x: 77, y: 41, rotation: 15, size: 44, iconIndex: 7 },
+  { x: 89, y: 45, rotation: -18, size: 46, iconIndex: 4 },
 
-  // Row 7 (y: 72-80)
-  { x: 2, y: 76, rotation: -15, size: 46, iconIndex: 7 },
-  { x: 16, y: 73, rotation: 10, size: 50, iconIndex: 4 },
-  { x: 30, y: 78, rotation: -22, size: 44, iconIndex: 6 },
-  { x: 44, y: 74, rotation: 18, size: 48, iconIndex: 8 },
-  { x: 58, y: 79, rotation: -8, size: 42, iconIndex: 1 },
-  { x: 72, y: 75, rotation: 12, size: 46, iconIndex: 3 },
-  { x: 86, y: 77, rotation: -18, size: 50, iconIndex: 0 },
-  { x: 98, y: 73, rotation: 5, size: 44, iconIndex: 5 },
+  // Row 7 (y: 48-54)
+  { x: 2, y: 51, rotation: -15, size: 46, iconIndex: 7 },
+  { x: 14, y: 49, rotation: 10, size: 50, iconIndex: 4 },
+  { x: 26, y: 53, rotation: -22, size: 44, iconIndex: 6 },
+  { x: 38, y: 50, rotation: 18, size: 48, iconIndex: 8 },
+  { x: 50, y: 54, rotation: -8, size: 42, iconIndex: 1 },
+  { x: 62, y: 51, rotation: 12, size: 46, iconIndex: 3 },
+  { x: 74, y: 49, rotation: -18, size: 50, iconIndex: 0 },
+  { x: 86, y: 53, rotation: 5, size: 44, iconIndex: 5 },
+  { x: 98, y: 50, rotation: -12, size: 42, iconIndex: 2 },
 
-  // Row 8 (y: 84-92)
-  { x: 7, y: 88, rotation: 22, size: 48, iconIndex: 2 },
-  { x: 21, y: 85, rotation: -10, size: 44, iconIndex: 5 },
-  { x: 35, y: 90, rotation: 15, size: 46, iconIndex: 1 },
-  { x: 49, y: 86, rotation: -25, size: 50, iconIndex: 4 },
-  { x: 63, y: 91, rotation: 8, size: 42, iconIndex: 7 },
-  { x: 77, y: 87, rotation: -12, size: 48, iconIndex: 6 },
-  { x: 91, y: 89, rotation: 20, size: 44, iconIndex: 8 },
+  // Row 8 (y: 56-62)
+  { x: 7, y: 59, rotation: 22, size: 48, iconIndex: 2 },
+  { x: 19, y: 57, rotation: -10, size: 44, iconIndex: 5 },
+  { x: 31, y: 61, rotation: 15, size: 46, iconIndex: 1 },
+  { x: 43, y: 58, rotation: -25, size: 50, iconIndex: 4 },
+  { x: 55, y: 62, rotation: 8, size: 42, iconIndex: 7 },
+  { x: 67, y: 59, rotation: -12, size: 48, iconIndex: 6 },
+  { x: 79, y: 57, rotation: 20, size: 44, iconIndex: 8 },
+  { x: 91, y: 61, rotation: -5, size: 46, iconIndex: 3 },
 
-  // Row 9 (y: 94-100)
-  { x: 4, y: 97, rotation: -8, size: 46, iconIndex: 8 },
-  { x: 18, y: 95, rotation: 15, size: 42, iconIndex: 3 },
-  { x: 32, y: 98, rotation: -18, size: 48, iconIndex: 0 },
-  { x: 46, y: 94, rotation: 10, size: 44, iconIndex: 2 },
-  { x: 60, y: 99, rotation: -5, size: 50, iconIndex: 5 },
-  { x: 74, y: 96, rotation: 22, size: 46, iconIndex: 1 },
-  { x: 88, y: 98, rotation: -15, size: 42, iconIndex: 4 },
+  // Row 9 (y: 64-70)
+  { x: 4, y: 67, rotation: -8, size: 46, iconIndex: 8 },
+  { x: 16, y: 65, rotation: 15, size: 42, iconIndex: 3 },
+  { x: 28, y: 69, rotation: -18, size: 48, iconIndex: 0 },
+  { x: 40, y: 66, rotation: 10, size: 44, iconIndex: 2 },
+  { x: 52, y: 70, rotation: -5, size: 50, iconIndex: 5 },
+  { x: 64, y: 67, rotation: 22, size: 46, iconIndex: 1 },
+  { x: 76, y: 65, rotation: -15, size: 42, iconIndex: 4 },
+  { x: 88, y: 69, rotation: 8, size: 48, iconIndex: 7 },
+  { x: 99, y: 66, rotation: -20, size: 44, iconIndex: 6 },
+
+  // Row 10 (y: 72-78)
+  { x: 1, y: 75, rotation: 12, size: 48, iconIndex: 4 },
+  { x: 13, y: 73, rotation: -18, size: 44, iconIndex: 6 },
+  { x: 25, y: 77, rotation: 5, size: 46, iconIndex: 8 },
+  { x: 37, y: 74, rotation: -10, size: 50, iconIndex: 1 },
+  { x: 49, y: 78, rotation: 25, size: 42, iconIndex: 3 },
+  { x: 61, y: 75, rotation: -22, size: 48, iconIndex: 0 },
+  { x: 73, y: 73, rotation: 15, size: 44, iconIndex: 5 },
+  { x: 85, y: 77, rotation: -8, size: 46, iconIndex: 2 },
+  { x: 97, y: 74, rotation: 18, size: 42, iconIndex: 7 },
+
+  // Row 11 (y: 80-86)
+  { x: 6, y: 83, rotation: -15, size: 46, iconIndex: 5 },
+  { x: 18, y: 81, rotation: 20, size: 48, iconIndex: 7 },
+  { x: 30, y: 85, rotation: -5, size: 44, iconIndex: 2 },
+  { x: 42, y: 82, rotation: 12, size: 50, iconIndex: 4 },
+  { x: 54, y: 86, rotation: -18, size: 42, iconIndex: 6 },
+  { x: 66, y: 83, rotation: 8, size: 46, iconIndex: 8 },
+  { x: 78, y: 81, rotation: -25, size: 48, iconIndex: 0 },
+  { x: 90, y: 85, rotation: 15, size: 44, iconIndex: 3 },
+
+  // Row 12 (y: 88-94)
+  { x: 3, y: 91, rotation: 10, size: 44, iconIndex: 3 },
+  { x: 15, y: 89, rotation: -12, size: 48, iconIndex: 1 },
+  { x: 27, y: 93, rotation: 22, size: 46, iconIndex: 6 },
+  { x: 39, y: 90, rotation: -8, size: 42, iconIndex: 5 },
+  { x: 51, y: 94, rotation: 18, size: 50, iconIndex: 0 },
+  { x: 63, y: 91, rotation: -20, size: 44, iconIndex: 2 },
+  { x: 75, y: 89, rotation: 5, size: 48, iconIndex: 7 },
+  { x: 87, y: 93, rotation: -15, size: 46, iconIndex: 4 },
+  { x: 98, y: 90, rotation: 12, size: 42, iconIndex: 8 },
+
+  // Row 13 (y: 96-100)
+  { x: 8, y: 98, rotation: -18, size: 46, iconIndex: 8 },
+  { x: 22, y: 97, rotation: 8, size: 44, iconIndex: 4 },
+  { x: 36, y: 99, rotation: -5, size: 48, iconIndex: 1 },
+  { x: 50, y: 97, rotation: 20, size: 42, iconIndex: 7 },
+  { x: 64, y: 99, rotation: -12, size: 46, iconIndex: 3 },
+  { x: 78, y: 98, rotation: 15, size: 50, iconIndex: 6 },
+  { x: 92, y: 97, rotation: -22, size: 44, iconIndex: 5 },
 ];
 
 export const LineArtBackground: React.FC = () => {

--- a/components/LineArtBackground/LineArtBackground.tsx
+++ b/components/LineArtBackground/LineArtBackground.tsx
@@ -28,43 +28,92 @@ const icons = [
 
 // Predefined scattered placements for a natural, hand-placed feel
 // Coordinates are percentages, rotations in degrees
+// Denser layout with more icons
 const placements = [
-  // Spread across the viewport with varied sizes and rotations
-  { x: 3, y: 5, rotation: -12, size: 48, iconIndex: 0 },
-  { x: 25, y: 2, rotation: 18, size: 42, iconIndex: 7 },
-  { x: 48, y: 8, rotation: -5, size: 52, iconIndex: 4 },
-  { x: 72, y: 3, rotation: 22, size: 46, iconIndex: 2 },
-  { x: 91, y: 6, rotation: -15, size: 50, iconIndex: 5 },
+  // Row 1 (y: 0-10)
+  { x: 2, y: 3, rotation: -12, size: 44, iconIndex: 0 },
+  { x: 14, y: 7, rotation: 22, size: 48, iconIndex: 7 },
+  { x: 28, y: 2, rotation: -8, size: 42, iconIndex: 4 },
+  { x: 42, y: 8, rotation: 15, size: 50, iconIndex: 2 },
+  { x: 56, y: 4, rotation: -18, size: 46, iconIndex: 5 },
+  { x: 70, y: 9, rotation: 10, size: 44, iconIndex: 1 },
+  { x: 84, y: 3, rotation: -5, size: 48, iconIndex: 8 },
+  { x: 96, y: 7, rotation: 20, size: 42, iconIndex: 3 },
 
-  { x: 8, y: 18, rotation: 10, size: 44, iconIndex: 5 },
-  { x: 35, y: 22, rotation: -20, size: 56, iconIndex: 3 },
-  { x: 60, y: 16, rotation: 8, size: 48, iconIndex: 8 },
-  { x: 85, y: 20, rotation: -12, size: 42, iconIndex: 6 },
+  // Row 2 (y: 12-20)
+  { x: 6, y: 16, rotation: 8, size: 46, iconIndex: 5 },
+  { x: 20, y: 13, rotation: -15, size: 52, iconIndex: 3 },
+  { x: 34, y: 18, rotation: 25, size: 44, iconIndex: 8 },
+  { x: 48, y: 14, rotation: -10, size: 48, iconIndex: 6 },
+  { x: 62, y: 19, rotation: 12, size: 42, iconIndex: 0 },
+  { x: 76, y: 15, rotation: -22, size: 50, iconIndex: 4 },
+  { x: 90, y: 17, rotation: 5, size: 46, iconIndex: 1 },
 
-  { x: 5, y: 35, rotation: 15, size: 50, iconIndex: 1 },
-  { x: 28, y: 38, rotation: -8, size: 46, iconIndex: 2 },
-  { x: 52, y: 32, rotation: 25, size: 54, iconIndex: 7 },
-  { x: 78, y: 36, rotation: -18, size: 48, iconIndex: 0 },
+  // Row 3 (y: 24-32)
+  { x: 3, y: 28, rotation: -18, size: 48, iconIndex: 1 },
+  { x: 16, y: 25, rotation: 15, size: 44, iconIndex: 2 },
+  { x: 30, y: 30, rotation: -8, size: 50, iconIndex: 7 },
+  { x: 44, y: 26, rotation: 20, size: 46, iconIndex: 0 },
+  { x: 58, y: 31, rotation: -12, size: 42, iconIndex: 5 },
+  { x: 72, y: 27, rotation: 8, size: 48, iconIndex: 3 },
+  { x: 86, y: 29, rotation: -20, size: 44, iconIndex: 6 },
+  { x: 98, y: 25, rotation: 12, size: 46, iconIndex: 8 },
 
-  { x: 15, y: 52, rotation: -10, size: 44, iconIndex: 4 },
-  { x: 42, y: 48, rotation: 12, size: 52, iconIndex: 8 },
-  { x: 68, y: 54, rotation: -22, size: 46, iconIndex: 5 },
-  { x: 92, y: 50, rotation: 8, size: 50, iconIndex: 3 },
+  // Row 4 (y: 36-44)
+  { x: 8, y: 40, rotation: 10, size: 46, iconIndex: 4 },
+  { x: 22, y: 37, rotation: -15, size: 50, iconIndex: 8 },
+  { x: 36, y: 42, rotation: 22, size: 44, iconIndex: 5 },
+  { x: 50, y: 38, rotation: -5, size: 48, iconIndex: 3 },
+  { x: 64, y: 43, rotation: 18, size: 42, iconIndex: 6 },
+  { x: 78, y: 39, rotation: -25, size: 46, iconIndex: 1 },
+  { x: 92, y: 41, rotation: 8, size: 50, iconIndex: 2 },
 
-  { x: 2, y: 68, rotation: 20, size: 48, iconIndex: 6 },
-  { x: 25, y: 65, rotation: -15, size: 54, iconIndex: 1 },
-  { x: 50, y: 70, rotation: 5, size: 42, iconIndex: 0 },
-  { x: 75, y: 66, rotation: -25, size: 50, iconIndex: 2 },
+  // Row 5 (y: 48-56)
+  { x: 1, y: 52, rotation: -10, size: 44, iconIndex: 6 },
+  { x: 14, y: 49, rotation: 20, size: 48, iconIndex: 0 },
+  { x: 28, y: 54, rotation: -18, size: 46, iconIndex: 2 },
+  { x: 42, y: 50, rotation: 12, size: 42, iconIndex: 7 },
+  { x: 56, y: 55, rotation: -8, size: 50, iconIndex: 4 },
+  { x: 70, y: 51, rotation: 15, size: 44, iconIndex: 8 },
+  { x: 84, y: 53, rotation: -22, size: 48, iconIndex: 5 },
+  { x: 97, y: 49, rotation: 5, size: 46, iconIndex: 3 },
 
-  { x: 12, y: 82, rotation: -8, size: 46, iconIndex: 7 },
-  { x: 38, y: 85, rotation: 18, size: 52, iconIndex: 4 },
-  { x: 62, y: 80, rotation: -12, size: 48, iconIndex: 6 },
-  { x: 88, y: 84, rotation: 15, size: 44, iconIndex: 8 },
+  // Row 6 (y: 60-68)
+  { x: 5, y: 64, rotation: 18, size: 48, iconIndex: 3 },
+  { x: 19, y: 61, rotation: -12, size: 44, iconIndex: 1 },
+  { x: 33, y: 66, rotation: 8, size: 50, iconIndex: 6 },
+  { x: 47, y: 62, rotation: -20, size: 46, iconIndex: 5 },
+  { x: 61, y: 67, rotation: 25, size: 42, iconIndex: 0 },
+  { x: 75, y: 63, rotation: -5, size: 48, iconIndex: 2 },
+  { x: 89, y: 65, rotation: 15, size: 44, iconIndex: 7 },
 
-  { x: 6, y: 95, rotation: 10, size: 50, iconIndex: 3 },
-  { x: 32, y: 92, rotation: -20, size: 46, iconIndex: 5 },
-  { x: 55, y: 96, rotation: 8, size: 52, iconIndex: 1 },
-  { x: 80, y: 94, rotation: -15, size: 48, iconIndex: 0 },
+  // Row 7 (y: 72-80)
+  { x: 2, y: 76, rotation: -15, size: 46, iconIndex: 7 },
+  { x: 16, y: 73, rotation: 10, size: 50, iconIndex: 4 },
+  { x: 30, y: 78, rotation: -22, size: 44, iconIndex: 6 },
+  { x: 44, y: 74, rotation: 18, size: 48, iconIndex: 8 },
+  { x: 58, y: 79, rotation: -8, size: 42, iconIndex: 1 },
+  { x: 72, y: 75, rotation: 12, size: 46, iconIndex: 3 },
+  { x: 86, y: 77, rotation: -18, size: 50, iconIndex: 0 },
+  { x: 98, y: 73, rotation: 5, size: 44, iconIndex: 5 },
+
+  // Row 8 (y: 84-92)
+  { x: 7, y: 88, rotation: 22, size: 48, iconIndex: 2 },
+  { x: 21, y: 85, rotation: -10, size: 44, iconIndex: 5 },
+  { x: 35, y: 90, rotation: 15, size: 46, iconIndex: 1 },
+  { x: 49, y: 86, rotation: -25, size: 50, iconIndex: 4 },
+  { x: 63, y: 91, rotation: 8, size: 42, iconIndex: 7 },
+  { x: 77, y: 87, rotation: -12, size: 48, iconIndex: 6 },
+  { x: 91, y: 89, rotation: 20, size: 44, iconIndex: 8 },
+
+  // Row 9 (y: 94-100)
+  { x: 4, y: 97, rotation: -8, size: 46, iconIndex: 8 },
+  { x: 18, y: 95, rotation: 15, size: 42, iconIndex: 3 },
+  { x: 32, y: 98, rotation: -18, size: 48, iconIndex: 0 },
+  { x: 46, y: 94, rotation: 10, size: 44, iconIndex: 2 },
+  { x: 60, y: 99, rotation: -5, size: 50, iconIndex: 5 },
+  { x: 74, y: 96, rotation: 22, size: 46, iconIndex: 1 },
+  { x: 88, y: 98, rotation: -15, size: 42, iconIndex: 4 },
 ];
 
 export const LineArtBackground: React.FC = () => {

--- a/components/LineArtBackground/LineArtBackground.tsx
+++ b/components/LineArtBackground/LineArtBackground.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import React from "react";
+import {
+  CoffeeIcon,
+  CameraIcon,
+  DumbbellIcon,
+  FishingIcon,
+  CodeIcon,
+  ElectronicsIcon,
+  PrinterIcon,
+  AirplaneIcon,
+  MotorcycleIcon,
+} from "./icons";
+
+// All available icons
+const icons = [
+  CoffeeIcon,
+  CameraIcon,
+  DumbbellIcon,
+  FishingIcon,
+  CodeIcon,
+  ElectronicsIcon,
+  PrinterIcon,
+  AirplaneIcon,
+  MotorcycleIcon,
+];
+
+// Predefined scattered placements for a natural, hand-placed feel
+// Coordinates are percentages, rotations in degrees
+const placements = [
+  // Spread across the viewport with varied sizes and rotations
+  { x: 3, y: 5, rotation: -12, size: 48, iconIndex: 0 },
+  { x: 25, y: 2, rotation: 18, size: 42, iconIndex: 7 },
+  { x: 48, y: 8, rotation: -5, size: 52, iconIndex: 4 },
+  { x: 72, y: 3, rotation: 22, size: 46, iconIndex: 2 },
+  { x: 91, y: 6, rotation: -15, size: 50, iconIndex: 5 },
+
+  { x: 8, y: 18, rotation: 10, size: 44, iconIndex: 5 },
+  { x: 35, y: 22, rotation: -20, size: 56, iconIndex: 3 },
+  { x: 60, y: 16, rotation: 8, size: 48, iconIndex: 8 },
+  { x: 85, y: 20, rotation: -12, size: 42, iconIndex: 6 },
+
+  { x: 5, y: 35, rotation: 15, size: 50, iconIndex: 1 },
+  { x: 28, y: 38, rotation: -8, size: 46, iconIndex: 2 },
+  { x: 52, y: 32, rotation: 25, size: 54, iconIndex: 7 },
+  { x: 78, y: 36, rotation: -18, size: 48, iconIndex: 0 },
+
+  { x: 15, y: 52, rotation: -10, size: 44, iconIndex: 4 },
+  { x: 42, y: 48, rotation: 12, size: 52, iconIndex: 8 },
+  { x: 68, y: 54, rotation: -22, size: 46, iconIndex: 5 },
+  { x: 92, y: 50, rotation: 8, size: 50, iconIndex: 3 },
+
+  { x: 2, y: 68, rotation: 20, size: 48, iconIndex: 6 },
+  { x: 25, y: 65, rotation: -15, size: 54, iconIndex: 1 },
+  { x: 50, y: 70, rotation: 5, size: 42, iconIndex: 0 },
+  { x: 75, y: 66, rotation: -25, size: 50, iconIndex: 2 },
+
+  { x: 12, y: 82, rotation: -8, size: 46, iconIndex: 7 },
+  { x: 38, y: 85, rotation: 18, size: 52, iconIndex: 4 },
+  { x: 62, y: 80, rotation: -12, size: 48, iconIndex: 6 },
+  { x: 88, y: 84, rotation: 15, size: 44, iconIndex: 8 },
+
+  { x: 6, y: 95, rotation: 10, size: 50, iconIndex: 3 },
+  { x: 32, y: 92, rotation: -20, size: 46, iconIndex: 5 },
+  { x: 55, y: 96, rotation: 8, size: 52, iconIndex: 1 },
+  { x: 80, y: 94, rotation: -15, size: 48, iconIndex: 0 },
+];
+
+export const LineArtBackground: React.FC = () => {
+  return (
+    <div className="line-art-background" aria-hidden="true">
+      {placements.map(({ x, y, rotation, size, iconIndex }, index) => {
+        const Icon = icons[iconIndex];
+        return (
+          <div
+            key={index}
+            className="line-art-icon-wrapper"
+            style={{
+              left: `${x}%`,
+              top: `${y}%`,
+              width: size,
+              height: size,
+              transform: `translate(-50%, -50%) rotate(${rotation}deg)`,
+            }}
+          >
+            <Icon className="line-art-icon" />
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default LineArtBackground;

--- a/components/LineArtBackground/icons.tsx
+++ b/components/LineArtBackground/icons.tsx
@@ -5,7 +5,7 @@ interface IconProps {
   className?: string;
 }
 
-// Coffee cup with steam
+// Coffee cup with steam - steam animates on hover
 export const CoffeeIcon: React.FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 48 48"
@@ -20,14 +20,16 @@ export const CoffeeIcon: React.FC<IconProps> = ({ className }) => (
     <path d="M8 18h24v20a4 4 0 01-4 4H12a4 4 0 01-4-4V18z" />
     {/* Handle */}
     <path d="M32 22h4a4 4 0 014 4v2a4 4 0 01-4 4h-4" />
-    {/* Steam lines */}
-    <path d="M14 8c0-2 2-4 2-6" />
-    <path d="M20 10c0-2.5 2.5-5 2.5-7.5" />
-    <path d="M26 8c0-2 2-4 2-6" />
+    {/* Steam lines - these will animate */}
+    <g className="line-art-steam">
+      <path d="M14 14c0-3 2-3 2-6s-2-3-2-6" />
+      <path d="M20 14c0-3 2-3 2-6s-2-3-2-6" />
+      <path d="M26 14c0-3 2-3 2-6s-2-3-2-6" />
+    </g>
   </svg>
 );
 
-// Camera
+// Camera - shutter click animation on hover
 export const CameraIcon: React.FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 48 48"
@@ -40,17 +42,22 @@ export const CameraIcon: React.FC<IconProps> = ({ className }) => (
   >
     {/* Camera body */}
     <rect x="4" y="14" width="40" height="28" rx="4" />
-    {/* Lens */}
-    <circle cx="24" cy="28" r="8" />
-    <circle cx="24" cy="28" r="4" />
+    {/* Lens - outer */}
+    <circle cx="24" cy="28" r="9" />
+    {/* Lens - inner (animates) */}
+    <circle cx="24" cy="28" r="5" className="line-art-shutter" />
+    {/* Lens - center */}
+    <circle cx="24" cy="28" r="2" />
     {/* Viewfinder bump */}
     <path d="M16 14V10a2 2 0 012-2h12a2 2 0 012 2v4" />
     {/* Flash */}
     <circle cx="38" cy="20" r="2" />
+    {/* Shutter button */}
+    <rect x="20" y="6" width="8" height="4" rx="1" />
   </svg>
 );
 
-// Dumbbell
+// Dumbbell - pumps up and down on hover
 export const DumbbellIcon: React.FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 48 48"
@@ -61,18 +68,20 @@ export const DumbbellIcon: React.FC<IconProps> = ({ className }) => (
     strokeLinejoin="round"
     className={className}
   >
-    {/* Bar */}
-    <path d="M12 24h24" />
-    {/* Left weight */}
-    <rect x="4" y="16" width="8" height="16" rx="1" />
-    <rect x="8" y="12" width="4" height="24" rx="1" />
-    {/* Right weight */}
-    <rect x="36" y="16" width="8" height="16" rx="1" />
-    <rect x="36" y="12" width="4" height="24" rx="1" />
+    <g className="line-art-pump">
+      {/* Bar */}
+      <path d="M12 24h24" />
+      {/* Left weight */}
+      <rect x="4" y="16" width="8" height="16" rx="1" />
+      <rect x="8" y="12" width="4" height="24" rx="1" />
+      {/* Right weight */}
+      <rect x="36" y="16" width="8" height="16" rx="1" />
+      <rect x="36" y="12" width="4" height="24" rx="1" />
+    </g>
   </svg>
 );
 
-// Fish with hook
+// Fishing rod with fish - line wobbles on hover
 export const FishingIcon: React.FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 48 48"
@@ -83,20 +92,27 @@ export const FishingIcon: React.FC<IconProps> = ({ className }) => (
     strokeLinejoin="round"
     className={className}
   >
-    {/* Fishing line */}
-    <path d="M38 4v12" />
+    {/* Fishing rod */}
+    <path d="M4 40L20 8" strokeWidth="2" />
+    {/* Rod handle */}
+    <path d="M4 40l-2 2" strokeWidth="2.5" />
+    {/* Rod tip */}
+    <path d="M20 8l2-2" />
+    {/* Fishing line - animates */}
+    <path d="M22 6c0 8 4 16 4 24" className="line-art-fishing-line" />
     {/* Hook */}
-    <path d="M38 16c0 4-4 6-4 8s2 4 0 6" />
-    {/* Fish body */}
-    <path d="M6 30c4-6 12-8 20-4 4 2 6 6 4 10s-8 6-14 4c-6-2-12-4-10-10z" />
-    {/* Fish eye */}
-    <circle cx="12" cy="32" r="1.5" />
-    {/* Fish tail */}
-    <path d="M26 34l6-4v10l-6-4" />
+    <path d="M26 30c2 2 4 4 2 6s-4 0-4-2" />
+    {/* Fish */}
+    <g className="line-art-fish">
+      <path d="M32 34c4-2 10-2 12 2s-2 6-6 6-8-2-8-4 0-2 2-4z" />
+      <circle cx="40" cy="37" r="1" />
+      {/* Fish tail */}
+      <path d="M32 36l-4-3v8l4-3" />
+    </g>
   </svg>
 );
 
-// Code brackets
+// Terminal/code window - cursor blinks on hover
 export const CodeIcon: React.FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 48 48"
@@ -107,16 +123,27 @@ export const CodeIcon: React.FC<IconProps> = ({ className }) => (
     strokeLinejoin="round"
     className={className}
   >
-    {/* Left bracket */}
-    <path d="M14 8l-8 16 8 16" />
-    {/* Right bracket */}
-    <path d="M34 8l8 16-8 16" />
-    {/* Slash */}
-    <path d="M28 6L20 42" />
+    {/* Terminal window */}
+    <rect x="4" y="6" width="40" height="36" rx="3" />
+    {/* Title bar */}
+    <path d="M4 14h40" />
+    {/* Window buttons */}
+    <circle cx="10" cy="10" r="1.5" />
+    <circle cx="16" cy="10" r="1.5" />
+    <circle cx="22" cy="10" r="1.5" />
+    {/* Code lines */}
+    <path d="M10 22h8" />
+    <path d="M14 28h12" />
+    <path d="M10 34h6" />
+    {/* Cursor - animates */}
+    <path d="M20 34v-4" className="line-art-cursor" strokeWidth="2" />
+    {/* Curly braces hint */}
+    <path d="M30 20c-2 0-3 1-3 3s1 3 0 3-1 1-1 2 0 1 1 2 1 3 0 3 3 3 3 3" />
+    <path d="M36 20c2 0 3 1 3 3s-1 3 0 3 1 1 1 2 0 1-1 2-1 3 0 3-3 3-3 3" />
   </svg>
 );
 
-// Circuit/chip
+// Circuit/chip - electricity pulses on hover
 export const ElectronicsIcon: React.FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 48 48"
@@ -137,12 +164,14 @@ export const ElectronicsIcon: React.FC<IconProps> = ({ className }) => (
     <path d="M12 18H6M12 24H6M12 30H6" />
     {/* Pins - right */}
     <path d="M36 18h6M36 24h6M36 30h6" />
-    {/* Inner detail */}
-    <circle cx="24" cy="24" r="4" />
+    {/* Inner circuit detail */}
+    <path d="M18 18h4v4h4v4h4" className="line-art-circuit" />
+    <circle cx="18" cy="18" r="1.5" className="line-art-pulse" />
+    <circle cx="30" cy="30" r="1.5" className="line-art-pulse" />
   </svg>
 );
 
-// 3D Printer
+// 3D Printer - print head moves on hover
 export const PrinterIcon: React.FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 48 48"
@@ -153,22 +182,35 @@ export const PrinterIcon: React.FC<IconProps> = ({ className }) => (
     strokeLinejoin="round"
     className={className}
   >
-    {/* Frame */}
-    <path d="M8 8v32M40 8v32M8 8h32M8 40h32" />
-    {/* Print bed */}
-    <rect x="12" y="32" width="24" height="4" rx="1" />
-    {/* Extruder */}
-    <rect x="20" y="12" width="8" height="6" rx="1" />
-    {/* Nozzle */}
-    <path d="M24 18v6" />
-    {/* Printed object (layer lines) */}
-    <path d="M16 32v-4h16v4" />
-    <path d="M18 28v-2h12v2" />
-    <path d="M20 26v-2h8v2" />
+    {/* Frame - vertical posts */}
+    <path d="M6 6v36" strokeWidth="2" />
+    <path d="M42 6v36" strokeWidth="2" />
+    {/* Frame - top bar with rails */}
+    <path d="M6 6h36" strokeWidth="2" />
+    <path d="M8 10h32" />
+    {/* X-axis gantry */}
+    <path d="M8 18h32" />
+    {/* Print head carriage */}
+    <g className="line-art-printhead">
+      <rect x="18" y="14" width="12" height="8" rx="1" />
+      {/* Nozzle */}
+      <path d="M24 22v4" strokeWidth="2" />
+      {/* Hotend */}
+      <path d="M22 26h4" />
+    </g>
+    {/* Heated bed */}
+    <rect x="8" y="38" width="32" height="4" rx="1" />
+    {/* Printed object - layer by layer */}
+    <path d="M16 38v-4h16v4" />
+    <path d="M18 34v-3h12v3" />
+    <path d="M20 31v-2h8v2" />
+    {/* Filament spool (side) */}
+    <ellipse cx="42" cy="14" rx="2" ry="4" />
+    <path d="M42 18c0 2-2 4-2 8" />
   </svg>
 );
 
-// Airplane
+// Airplane - flies/tilts on hover
 export const AirplaneIcon: React.FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 48 48"
@@ -179,19 +221,28 @@ export const AirplaneIcon: React.FC<IconProps> = ({ className }) => (
     strokeLinejoin="round"
     className={className}
   >
-    {/* Fuselage */}
-    <path d="M4 24h36c2 0 4-1 4-3s-2-3-4-3c-8 0-12 2-16 6H4" />
-    {/* Wings */}
-    <path d="M18 24l-4 12h4l6-12" />
-    <path d="M20 18l8-10h-4l-8 10" />
-    {/* Tail */}
-    <path d="M6 24l-2-6h4" />
-    {/* Engine */}
-    <ellipse cx="30" cy="24" rx="2" ry="3" />
+    <g className="line-art-fly">
+      {/* Fuselage */}
+      <path d="M2 24c0 0 4-4 14-4h20c4 0 8 2 10 4s-6 4-10 4H16c-10 0-14-4-14-4z" />
+      {/* Cockpit windows */}
+      <path d="M38 22c2 0 4 1 4 2s-2 2-4 2" />
+      {/* Wings */}
+      <path d="M18 20l-6-10h4l8 10" />
+      <path d="M18 28l-6 10h4l8-10" />
+      {/* Tail fin */}
+      <path d="M6 24v-8l6 4" />
+      {/* Tail wings */}
+      <path d="M8 20l-4-4h3" />
+      <path d="M8 28l-4 4h3" />
+      {/* Engine */}
+      <ellipse cx="28" cy="24" rx="3" ry="2" />
+      {/* Window line */}
+      <path d="M20 23h12" strokeDasharray="2 2" />
+    </g>
   </svg>
 );
 
-// Motorcycle
+// Motorcycle - wheels spin on hover
 export const MotorcycleIcon: React.FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 48 48"
@@ -202,21 +253,37 @@ export const MotorcycleIcon: React.FC<IconProps> = ({ className }) => (
     strokeLinejoin="round"
     className={className}
   >
-    {/* Wheels */}
-    <circle cx="10" cy="34" r="6" />
-    <circle cx="38" cy="34" r="6" />
-    {/* Frame */}
-    <path d="M10 34l8-12h8l4 6" />
-    <path d="M30 28l8 6" />
-    {/* Tank & seat */}
-    <path d="M16 22c2-2 6-2 8 0" />
-    <path d="M24 22h6l2 4" />
+    {/* Wheels with spokes */}
+    <g className="line-art-wheel-back">
+      <circle cx="10" cy="34" r="7" />
+      <circle cx="10" cy="34" r="3" />
+      <path d="M10 27v3M10 38v3M3 34h3M14 34h3" />
+    </g>
+    <g className="line-art-wheel-front">
+      <circle cx="40" cy="34" r="6" />
+      <circle cx="40" cy="34" r="2.5" />
+      <path d="M40 28v2.5M40 37.5v2.5M34 34h2.5M43.5 34h2.5" />
+    </g>
+    {/* Engine block */}
+    <path d="M16 30l4-2h8l2 4h-12z" />
+    <path d="M18 32h8" />
+    {/* Frame - main tube */}
+    <path d="M10 34l6-10" strokeWidth="2" />
+    <path d="M16 24l8-4" strokeWidth="2" />
+    {/* Gas tank */}
+    <ellipse cx="22" cy="18" rx="6" ry="3" />
+    {/* Seat */}
+    <path d="M26 16c4 0 8 2 10 6" strokeWidth="2" />
     {/* Handlebars */}
-    <path d="M18 22l-4-6h8" />
-    {/* Exhaust */}
-    <path d="M26 32h8" />
-    {/* Fender */}
-    <path d="M4 30c2-1 4-1 6 0" />
-    <path d="M38 28c2-1 4 0 6 2" />
+    <path d="M24 20l8-8" />
+    <path d="M30 12h6" strokeWidth="2" />
+    <path d="M32 10v4" />
+    {/* Front fork */}
+    <path d="M36 18l4 16" strokeWidth="2" />
+    {/* Exhaust pipes */}
+    <path d="M20 32c-2 4-4 6-6 6" />
+    <path d="M22 32c-2 4-4 6-6 6" />
+    {/* Headlight */}
+    <circle cx="42" cy="24" r="2" />
   </svg>
 );

--- a/components/LineArtBackground/icons.tsx
+++ b/components/LineArtBackground/icons.tsx
@@ -171,7 +171,7 @@ export const ElectronicsIcon: React.FC<IconProps> = ({ className }) => (
   </svg>
 );
 
-// 3D Printer - print head moves on hover
+// 3D Printer - simple box frame with nozzle
 export const PrinterIcon: React.FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 48 48"
@@ -182,35 +182,23 @@ export const PrinterIcon: React.FC<IconProps> = ({ className }) => (
     strokeLinejoin="round"
     className={className}
   >
-    {/* Frame - vertical posts */}
-    <path d="M6 6v36" strokeWidth="2" />
-    <path d="M42 6v36" strokeWidth="2" />
-    {/* Frame - top bar with rails */}
-    <path d="M6 6h36" strokeWidth="2" />
-    <path d="M8 10h32" />
-    {/* X-axis gantry */}
-    <path d="M8 18h32" />
-    {/* Print head carriage */}
+    {/* Simple cube frame */}
+    <path d="M8 8h32v32H8z" />
+    <path d="M8 8l6-4h20l6 4" />
+    <path d="M40 8l4 4v24l-4 4" />
+    {/* Print head - moves on hover */}
     <g className="line-art-printhead">
-      <rect x="18" y="14" width="12" height="8" rx="1" />
-      {/* Nozzle */}
-      <path d="M24 22v4" strokeWidth="2" />
-      {/* Hotend */}
-      <path d="M22 26h4" />
+      <rect x="18" y="12" width="12" height="6" rx="1" />
+      <path d="M24 18v8" strokeWidth="2" />
     </g>
-    {/* Heated bed */}
-    <rect x="8" y="38" width="32" height="4" rx="1" />
-    {/* Printed object - layer by layer */}
-    <path d="M16 38v-4h16v4" />
-    <path d="M18 34v-3h12v3" />
-    <path d="M20 31v-2h8v2" />
-    {/* Filament spool (side) */}
-    <ellipse cx="42" cy="14" rx="2" ry="4" />
-    <path d="M42 18c0 2-2 4-2 8" />
+    {/* Bed */}
+    <path d="M12 36h24" strokeWidth="2" />
+    {/* Printed object */}
+    <path d="M18 36v-6h12v6" />
   </svg>
 );
 
-// Airplane - flies/tilts on hover
+// Airplane - simple side view silhouette
 export const AirplaneIcon: React.FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 48 48"
@@ -223,26 +211,20 @@ export const AirplaneIcon: React.FC<IconProps> = ({ className }) => (
   >
     <g className="line-art-fly">
       {/* Fuselage */}
-      <path d="M2 24c0 0 4-4 14-4h20c4 0 8 2 10 4s-6 4-10 4H16c-10 0-14-4-14-4z" />
-      {/* Cockpit windows */}
-      <path d="M38 22c2 0 4 1 4 2s-2 2-4 2" />
-      {/* Wings */}
-      <path d="M18 20l-6-10h4l8 10" />
-      <path d="M18 28l-6 10h4l8-10" />
-      {/* Tail fin */}
-      <path d="M6 24v-8l6 4" />
-      {/* Tail wings */}
-      <path d="M8 20l-4-4h3" />
-      <path d="M8 28l-4 4h3" />
-      {/* Engine */}
-      <ellipse cx="28" cy="24" rx="3" ry="2" />
-      {/* Window line */}
-      <path d="M20 23h12" strokeDasharray="2 2" />
+      <path d="M4 24h36c3 0 6-2 6-4s-3-2-6-2H14" />
+      <path d="M4 24c0 2 2 4 6 4h30c3 0 4-2 4-4" />
+      {/* Wing */}
+      <path d="M16 24l-4-14h6l6 14" />
+      {/* Tail */}
+      <path d="M6 24l-2-8h4" />
+      <path d="M6 20h6" />
+      {/* Windows */}
+      <circle cx="38" cy="22" r="1.5" />
     </g>
   </svg>
 );
 
-// Motorcycle - wheels spin on hover
+// Motorcycle - simple profile with spinning wheels
 export const MotorcycleIcon: React.FC<IconProps> = ({ className }) => (
   <svg
     viewBox="0 0 48 48"
@@ -253,37 +235,27 @@ export const MotorcycleIcon: React.FC<IconProps> = ({ className }) => (
     strokeLinejoin="round"
     className={className}
   >
-    {/* Wheels with spokes */}
+    {/* Back wheel */}
     <g className="line-art-wheel-back">
-      <circle cx="10" cy="34" r="7" />
-      <circle cx="10" cy="34" r="3" />
-      <path d="M10 27v3M10 38v3M3 34h3M14 34h3" />
+      <circle cx="10" cy="32" r="8" />
+      <circle cx="10" cy="32" r="3" />
     </g>
+    {/* Front wheel */}
     <g className="line-art-wheel-front">
-      <circle cx="40" cy="34" r="6" />
-      <circle cx="40" cy="34" r="2.5" />
-      <path d="M40 28v2.5M40 37.5v2.5M34 34h2.5M43.5 34h2.5" />
+      <circle cx="38" cy="32" r="7" />
+      <circle cx="38" cy="32" r="2.5" />
     </g>
-    {/* Engine block */}
-    <path d="M16 30l4-2h8l2 4h-12z" />
-    <path d="M18 32h8" />
-    {/* Frame - main tube */}
-    <path d="M10 34l6-10" strokeWidth="2" />
-    <path d="M16 24l8-4" strokeWidth="2" />
-    {/* Gas tank */}
-    <ellipse cx="22" cy="18" rx="6" ry="3" />
+    {/* Body frame */}
+    <path d="M10 32l8-14h8l12 14" strokeWidth="2" />
+    {/* Tank */}
+    <ellipse cx="22" cy="16" rx="5" ry="2.5" />
     {/* Seat */}
-    <path d="M26 16c4 0 8 2 10 6" strokeWidth="2" />
+    <path d="M26 14c3 0 6 2 8 6" strokeWidth="2" />
     {/* Handlebars */}
-    <path d="M24 20l8-8" />
-    <path d="M30 12h6" strokeWidth="2" />
-    <path d="M32 10v4" />
-    {/* Front fork */}
-    <path d="M36 18l4 16" strokeWidth="2" />
-    {/* Exhaust pipes */}
-    <path d="M20 32c-2 4-4 6-6 6" />
-    <path d="M22 32c-2 4-4 6-6 6" />
-    {/* Headlight */}
-    <circle cx="42" cy="24" r="2" />
+    <path d="M32 12l6-4" strokeWidth="2" />
+    {/* Fork */}
+    <path d="M34 18l4 14" strokeWidth="1.5" />
+    {/* Exhaust */}
+    <path d="M18 28l-6 8" />
   </svg>
 );

--- a/components/LineArtBackground/icons.tsx
+++ b/components/LineArtBackground/icons.tsx
@@ -1,0 +1,222 @@
+import React from "react";
+
+// Shared props for all icons
+interface IconProps {
+  className?: string;
+}
+
+// Coffee cup with steam
+export const CoffeeIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    viewBox="0 0 48 48"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    {/* Cup body */}
+    <path d="M8 18h24v20a4 4 0 01-4 4H12a4 4 0 01-4-4V18z" />
+    {/* Handle */}
+    <path d="M32 22h4a4 4 0 014 4v2a4 4 0 01-4 4h-4" />
+    {/* Steam lines */}
+    <path d="M14 8c0-2 2-4 2-6" />
+    <path d="M20 10c0-2.5 2.5-5 2.5-7.5" />
+    <path d="M26 8c0-2 2-4 2-6" />
+  </svg>
+);
+
+// Camera
+export const CameraIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    viewBox="0 0 48 48"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    {/* Camera body */}
+    <rect x="4" y="14" width="40" height="28" rx="4" />
+    {/* Lens */}
+    <circle cx="24" cy="28" r="8" />
+    <circle cx="24" cy="28" r="4" />
+    {/* Viewfinder bump */}
+    <path d="M16 14V10a2 2 0 012-2h12a2 2 0 012 2v4" />
+    {/* Flash */}
+    <circle cx="38" cy="20" r="2" />
+  </svg>
+);
+
+// Dumbbell
+export const DumbbellIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    viewBox="0 0 48 48"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    {/* Bar */}
+    <path d="M12 24h24" />
+    {/* Left weight */}
+    <rect x="4" y="16" width="8" height="16" rx="1" />
+    <rect x="8" y="12" width="4" height="24" rx="1" />
+    {/* Right weight */}
+    <rect x="36" y="16" width="8" height="16" rx="1" />
+    <rect x="36" y="12" width="4" height="24" rx="1" />
+  </svg>
+);
+
+// Fish with hook
+export const FishingIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    viewBox="0 0 48 48"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    {/* Fishing line */}
+    <path d="M38 4v12" />
+    {/* Hook */}
+    <path d="M38 16c0 4-4 6-4 8s2 4 0 6" />
+    {/* Fish body */}
+    <path d="M6 30c4-6 12-8 20-4 4 2 6 6 4 10s-8 6-14 4c-6-2-12-4-10-10z" />
+    {/* Fish eye */}
+    <circle cx="12" cy="32" r="1.5" />
+    {/* Fish tail */}
+    <path d="M26 34l6-4v10l-6-4" />
+  </svg>
+);
+
+// Code brackets
+export const CodeIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    viewBox="0 0 48 48"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    {/* Left bracket */}
+    <path d="M14 8l-8 16 8 16" />
+    {/* Right bracket */}
+    <path d="M34 8l8 16-8 16" />
+    {/* Slash */}
+    <path d="M28 6L20 42" />
+  </svg>
+);
+
+// Circuit/chip
+export const ElectronicsIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    viewBox="0 0 48 48"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    {/* Chip body */}
+    <rect x="12" y="12" width="24" height="24" rx="2" />
+    {/* Pins - top */}
+    <path d="M18 12V6M24 12V6M30 12V6" />
+    {/* Pins - bottom */}
+    <path d="M18 36v6M24 36v6M30 36v6" />
+    {/* Pins - left */}
+    <path d="M12 18H6M12 24H6M12 30H6" />
+    {/* Pins - right */}
+    <path d="M36 18h6M36 24h6M36 30h6" />
+    {/* Inner detail */}
+    <circle cx="24" cy="24" r="4" />
+  </svg>
+);
+
+// 3D Printer
+export const PrinterIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    viewBox="0 0 48 48"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    {/* Frame */}
+    <path d="M8 8v32M40 8v32M8 8h32M8 40h32" />
+    {/* Print bed */}
+    <rect x="12" y="32" width="24" height="4" rx="1" />
+    {/* Extruder */}
+    <rect x="20" y="12" width="8" height="6" rx="1" />
+    {/* Nozzle */}
+    <path d="M24 18v6" />
+    {/* Printed object (layer lines) */}
+    <path d="M16 32v-4h16v4" />
+    <path d="M18 28v-2h12v2" />
+    <path d="M20 26v-2h8v2" />
+  </svg>
+);
+
+// Airplane
+export const AirplaneIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    viewBox="0 0 48 48"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    {/* Fuselage */}
+    <path d="M4 24h36c2 0 4-1 4-3s-2-3-4-3c-8 0-12 2-16 6H4" />
+    {/* Wings */}
+    <path d="M18 24l-4 12h4l6-12" />
+    <path d="M20 18l8-10h-4l-8 10" />
+    {/* Tail */}
+    <path d="M6 24l-2-6h4" />
+    {/* Engine */}
+    <ellipse cx="30" cy="24" rx="2" ry="3" />
+  </svg>
+);
+
+// Motorcycle
+export const MotorcycleIcon: React.FC<IconProps> = ({ className }) => (
+  <svg
+    viewBox="0 0 48 48"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+  >
+    {/* Wheels */}
+    <circle cx="10" cy="34" r="6" />
+    <circle cx="38" cy="34" r="6" />
+    {/* Frame */}
+    <path d="M10 34l8-12h8l4 6" />
+    <path d="M30 28l8 6" />
+    {/* Tank & seat */}
+    <path d="M16 22c2-2 6-2 8 0" />
+    <path d="M24 22h6l2 4" />
+    {/* Handlebars */}
+    <path d="M18 22l-4-6h8" />
+    {/* Exhaust */}
+    <path d="M26 32h8" />
+    {/* Fender */}
+    <path d="M4 30c2-1 4-1 6 0" />
+    <path d="M38 28c2-1 4 0 6 2" />
+  </svg>
+);

--- a/components/LineArtBackground/index.ts
+++ b/components/LineArtBackground/index.ts
@@ -1,0 +1,1 @@
+export { LineArtBackground, default } from "./LineArtBackground";


### PR DESCRIPTION
Implement a decorative background layer featuring hand-drawn style
line-art icons representing various interests: coffee, photography,
strength training, fishing, coding, electronics, 3D printing, travel,
and motorcycles.

- Create 9 custom SVG icons with minimalist single-stroke design
- Position icons in a scattered, natural pattern across viewport
- Use theme-aware opacity (6% light / 8% dark) for subtle effect
- Fixed positioning with pointer-events disabled for non-interference