### PR TITLE
KJSW-5: Fix broken callout styling on blog post

### DIFF
--- a/src/content/blog/ic-to-em-and-back.md
+++ b/src/content/blog/ic-to-em-and-back.md
@@ -14,14 +14,14 @@ reviewers:
 ---
 
 # Summary
-In 2023, 3.5 years after joining Spotify as an Individual Contributor (<span className="text-muted">_IC – someone who doesn't have reports and typically makes direct contribution to deliverables_</span>), I transitioned to a management role for the second time in my career. After 2 years in that Engineering Manager role, I’m transitioning back to being an IC.
+In 2023, 3.5 years after joining Spotify as an Individual Contributor (<span class="text-muted">_IC – someone who doesn't have reports and typically makes direct contribution to deliverables_</span>), I transitioned to a management role for the second time in my career. After 2 years in that Engineering Manager role, I’m transitioning back to being an IC.
 
 In this post I’m going to share my reasoning for moving back to IC. I cover the benefits of being an EM compared to a Senior Engineer, my thoughts on job security in the current tech job market, and a little bit on how AI may influence the future of the IC role.
 
 My main goal for this post is to capture this decision for my future self to review. I thought it may be interesting for others too and some folks might have some interesting advice, commentary or shared experience to connect with me on; so here goes.
 
 # What prompted my move back to IC?
-<div className="mt-4 mb-4 px-3 py-2 rounded-xl border-2 border-muted">
+<div class="mt-4 mb-4 px-3 py-2 rounded-xl border-2 border-muted">
 **_TL;DR_: I founded an internal product that ended up being owned by an org that couldn’t justify having more EMs**
 
 I can't share much about the product I've founded, but essentially it aims to solve a great deal of friction that Spotify has been experiencing in disseminating high-level company goals and then carrying out a series of dependency resolution and prioritization discussions.

--- a/src/content/blog/ic-to-em-and-back.md
+++ b/src/content/blog/ic-to-em-and-back.md
@@ -22,6 +22,7 @@ My main goal for this post is to capture this decision for my future self to rev
 
 # What prompted my move back to IC?
 <div class="mt-4 mb-4 px-3 py-2 rounded-xl border-2 border-muted">
+
 **_TL;DR_: I founded an internal product that ended up being owned by an org that couldn’t justify having more EMs**
 
 I can't share much about the product I've founded, but essentially it aims to solve a great deal of friction that Spotify has been experiencing in disseminating high-level company goals and then carrying out a series of dependency resolution and prioritization discussions.


### PR DESCRIPTION
## Summary
- Fix broken callout box and muted text in the "IC to EM and back" blog post
- Changed `className` (JSX) to `class` (HTML) — the file is `.md` not `.mdx`, so inline HTML needs standard attributes

## Test plan
- [ ] Run `pnpm build` — passes
- [ ] Visit `/posts/ic-to-em-and-back/` and verify the TL;DR callout box has a rounded muted border
- [ ] Verify the IC definition text renders in muted color

🤖 Generated with [Claude Code](https://claude.com/claude-code)