### PR TITLE
KJSW-9: Symlink Claude settings in Orca worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ npm-debug.log*
 .obsidian/
 
 worktrees/
+.orca/.bootstrapped

--- a/.orca/pre-terminal
+++ b/.orca/pre-terminal
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p .claude
+ln -sf "$ORCA_REPO_ROOT/.claude/settings.local.json" .claude/settings.local.json


### PR DESCRIPTION
## Summary
- Adds `.orca/pre-terminal` script that symlinks `.claude/settings.local.json` from the main repo root into worktrees, so permission changes propagate automatically
- Adds `.orca/.bootstrapped` to `.gitignore` to prevent Orca's marker file from being tracked

## Test plan
- [ ] Verify `.orca/pre-terminal` is executable
- [ ] Create a new Orca worktree and confirm `.claude/settings.local.json` is symlinked to the repo root's copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)