### PR TITLE
KJSW-10: Fix missing meta link images after Astro migration

### DIFF
--- a/src/content/blog/19-learnings-from-pushing-my-physique.mdx
+++ b/src/content/blog/19-learnings-from-pushing-my-physique.mdx
@@ -2,7 +2,7 @@
 title: 19 learnings from pushing my physique for 6 months
 description: 19 things I learned by losing 10kg over six months whilst building strength and managing a high-intensity job
 date: 2025-06-03
-shareImage: /_next/image?url=%2Fposts%2Fimages%2Fcut-social.jpg&w=3840&q=75
+shareImage: /posts/images/cut-social.jpg
 ---
 
 <div className="flex gap-4 mb-6 fade-in-fast">

--- a/src/content/blog/multi-agent-spec-review.mdx
+++ b/src/content/blog/multi-agent-spec-review.mdx
@@ -2,7 +2,7 @@
 title: Multi-agent spec review
 date: 2026-01-20
 description: A method for improving spec-driven development with AI agents by using multiple sub-agents to review and iterate on specs.
-shareImage: /_next/image?url=%2Fposts%2Fimages%2Fmulti-agent-spec-review.jpg&w=1920&q=75
+shareImage: /posts/images/multi-agent-spec-review.jpg
 ---
 
 <Image src="/posts/images/multi-agent-spec-review.jpg" className="rounded-lg" alt="Image of remote agents collaborating"/>

--- a/src/content/blog/remote-agents.mdx
+++ b/src/content/blog/remote-agents.mdx
@@ -2,7 +2,7 @@
 title: Remote Agents
 description: Exploring the concept of Remote Agents in AI development
 date: 2025-07-05
-shareImage: /_next/image?url=%2Fposts%2Fimages%2Fremote-agents.jpg&w=3840&q=75
+shareImage: /posts/images/remote-agents.jpg
 ---
 
 <Image src="/posts/images/remote-agents.jpg" className="rounded-lg" alt="Image of Remote Agents"/>


### PR DESCRIPTION
## Summary
- Replace Next.js `/_next/image?url=...` share image URLs in 3 blog post frontmatter files with direct `/posts/images/` paths
- These URLs were leftover from the Next.js migration and produced broken `og:image` / `twitter:image` meta tags

## Affected posts
- `remote-agents.mdx`
- `multi-agent-spec-review.mdx`
- `19-learnings-from-pushing-my-physique.mdx`

## Test plan
- [ ] Run `pnpm build` and verify no errors
- [ ] Inspect built HTML for affected posts — confirm `og:image` content is e.g. `https://kylejs.me/posts/images/remote-agents.jpg`
- [ ] Test share preview on a social media debugger (e.g. https://cards-dev.twitter.com/validator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)