### PR TITLE
KJSW-4: Fix theme popover cut off on mobile home page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -84,6 +84,16 @@ import meImage from "../../public/me.jpg";
     function updatePosition() {
       const isMobile = window.innerWidth < 500;
       btn!.className = `fixed right-4 z-[1000] flex justify-end ${isMobile ? "bottom-4" : "top-4"}`;
+
+      const popover = document.getElementById("theme-popover");
+      if (!popover) return;
+      if (isMobile) {
+        popover.classList.remove("top-10");
+        popover.classList.add("bottom-12");
+      } else {
+        popover.classList.remove("bottom-12");
+        popover.classList.add("top-10");
+      }
     }
 
     updatePosition();


### PR DESCRIPTION
## Summary
- On mobile (<500px), the home page theme button moves to the bottom-right of the viewport, but the popover (light/dark/system options) still opened downward — extending off-screen
- Fixed by toggling the popover's vertical position classes in the existing `updatePosition` JS function: opens upward (`bottom-12`) when button is at bottom, downward (`top-10`) when at top

## Test plan
- [ ] Open home page at mobile width (<500px), click theme button — popover should open **upward**
- [ ] Open home page at desktop width (>=500px), click theme button — popover should open **downward**
- [ ] Resize browser across 500px threshold — popover direction should switch
- [ ] Navigate away and back via ViewTransitions — button and popover still work
- [ ] Select each theme option on mobile — popover closes and theme applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)