### PR TITLE
KJSW-11: Restore favicon lost during Astro migration

### DIFF
--- a/public/favicon.ico
+++ b/public/favicon.ico
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:657b8e626ae4b8d38e7b85a2f0383561ae440e0175aa0503570cbb1239b59dbc
+size 15406

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -30,6 +30,7 @@ const imageUrl = ogImage ? `${siteUrl}${ogImage}` : undefined;
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <title>{title}</title>
     <meta name="description" content={description} />
 


### PR DESCRIPTION
## Summary
- Recovered the original `favicon.ico` from Git LFS history and placed it in `public/`
- Added `<link rel="icon">` tag to `Base.astro` so browsers load the favicon

The favicon was deleted during the Next.js → Astro migration because Next.js automatically serves `app/favicon.ico` while Astro requires an explicit file in `public/` and a link tag in the HTML head.

## Test plan
- [ ] Run `pnpm dev` and verify favicon appears in browser tab
- [ ] Run `pnpm build` and verify `dist/favicon.ico` exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)