### PR TITLE
KJSW-12: Restore high-quality profile image on home page

### DIFF
--- a/public/me.jpg
+++ b/public/me.jpg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3123887f1477edb0465b471ee945097aa8735926dc8b5411ba0439095bff7f1b
-size 93998
+oid sha256:54b138c0766ed5d36d87c1c1f37f0b2d0050eb992f8d72cdfd217bb53b7b54f3
+size 293687

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -19,8 +19,8 @@ import meImage from "../../public/me.jpg";
           <Image
             src={meImage}
             alt="Headshot of Kyle Satti"
-            width={144}
-            height={144}
+            width={288}
+            height={288}
             loading="eager"
           />
         </div>


### PR DESCRIPTION
## Summary
- Replaced the aggressively compressed profile image (600x600, 94KB) with a higher quality version (874x874, 294KB)
- Increased `<Image>` output dimensions from 144x144 to 288x288 for crisp 2x retina rendering (CSS container still constrains display to 144px)

## Test plan
- [ ] Run `pnpm dev` and verify the profile image on the home page looks sharp
- [ ] Check on a retina display that the image is crisp at the 144px display size
- [ ] Run `pnpm build` to confirm production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)