### PR TITLE
KJSW-14: Enable viewport prefetching for instant navigation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,6 +10,10 @@ import rehypeMermaidBlocks from "./src/lib/rehype-mermaid-blocks.ts";
 export default defineConfig({
   site: "https://kylejs.me",
   output: "static",
+  prefetch: {
+    prefetchAll: true,
+    defaultStrategy: "viewport",
+  },
   markdown: {
     remarkPlugins: [remarkGfm],
     rehypePlugins: [rehypeHeadingIds, rehypeCallouts, rehypeMermaidBlocks],


### PR DESCRIPTION
## Summary
- Adds `prefetch: { prefetchAll: true, defaultStrategy: "viewport" }` to `astro.config.mjs`
- Pages are now prefetched as soon as their links scroll into view, eliminating the network round-trip delay on click
- Matches NextJS's default prefetching behavior for instant-feeling navigation

## Test plan
- [ ] Run `pnpm dev` and navigate between pages — should feel instant
- [ ] Open DevTools Network tab — confirm prefetch requests fire when links enter the viewport
- [ ] Verify `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)