### PR TITLE
KJSW-15: Fix share image meta tags after asset pipeline migration

### DIFF
--- a/src/pages/posts/[id].astro
+++ b/src/pages/posts/[id].astro
@@ -1,5 +1,7 @@
 ---
 import { getCollection, render } from "astro:content";
+import { getImage } from "astro:assets";
+import type { ImageMetadata } from "astro";
 import Post from "../../layouts/Post.astro";
 import PostHeader from "../../components/PostHeader.astro";
 import PostFooter from "../../components/PostFooter.astro";
@@ -23,7 +25,25 @@ const { Content } = await render(post);
 
 const baseUrl = "https://kylejs.me";
 const slug = post.id;
-const imagePath = post.data.shareImage || "/me.jpg";
+
+const shareImages = import.meta.glob<{ default: ImageMetadata }>(
+  "/src/assets/posts/images/*.{jpeg,jpg,png,webp}",
+);
+
+let imagePath = "/me.jpg";
+if (post.data.shareImage) {
+  const filename = post.data.shareImage.split("/").pop();
+  const matchKey = Object.keys(shareImages).find((k) => k.endsWith(`/${filename}`));
+  if (matchKey) {
+    const imported = (await shareImages[matchKey]()).default;
+    const optimized = await getImage({ src: imported, format: "jpg", width: 1200 });
+    imagePath = optimized.src;
+  } else {
+    console.warn(
+      `[posts/${slug}] shareImage "${post.data.shareImage}" not found in src/assets/posts/images/, falling back to /me.jpg`,
+    );
+  }
+}
 ---
 
 <Post


### PR DESCRIPTION
## Summary
- `shareImage` frontmatter (e.g. `/posts/images/remote-agents.jpg`) has been 404ing on Facebook/WhatsApp/Slack since KJSW-2 moved those files from `public/` to `src/assets/`. KJSW-10 landed 38 minutes after KJSW-2 and "fixed" the legacy `/_next/image?url=…` paths to plain `/posts/images/…`, but the files were no longer at that public path.
- Resolve the `shareImage` filename through `import.meta.glob('/src/assets/posts/images/*')` and `getImage()` so `og:image` / `twitter:image` emit the hashed `/_astro/<file>.<hash>.jpg` URL the build actually produces. JPEG forced for max scraper compatibility.
- No frontmatter changes; no schema changes. Posts without `shareImage` continue to fall back to `/me.jpg`. Unmatched filenames log a build-time `console.warn` instead of silently shipping a broken URL.

## Test plan
- [x] `pnpm build` succeeds; build emits `_astro/cut-social.<hash>.jpg`, `_astro/remote-agents.<hash>.jpg`, `_astro/multi-agent-spec-review.<hash>.jpg`
- [x] Built HTML for the three posts with `shareImage` shows absolute `https://kylejs.me/_astro/<file>.<hash>.jpg` in `og:image` and `twitter:image`
- [x] Built HTML for a post without `shareImage` (e.g. `why-blog`) falls back to `https://kylejs.me/me.jpg`
- [x] `pnpm lint` clean
- [ ] Post-merge: paste a deployed post URL into the [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/), click "Scrape Again", confirm the preview image renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)