### PR TITLE
Add a morphing fractal background to the home page

### DIFF
--- a/src/components/FractalBackground.astro
+++ b/src/components/FractalBackground.astro
@@ -17,20 +17,20 @@ const { fill = 0.98 } = Astro.props;
     width: 100%;
     height: 100%;
     pointer-events: none;
-    opacity: 0;
-    transition: opacity 2s ease-in;
     /* Soften the edges so the pattern dissolves rather than stopping at the viewport. */
     -webkit-mask-image: radial-gradient(ellipse 70% 70% at 50% 50%, #000 15%, transparent 100%);
     mask-image: radial-gradient(ellipse 70% 70% at 50% 50%, #000 15%, transparent 100%);
   }
 
-  .fractal-bg.is-ready {
-    opacity: 1;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
+  /*
+   * On a phone the card fills the middle of the screen, so the only part of the
+   * tree anyone can see is the part a centred vignette would fade out. Keep the
+   * falloff, but push it right out to the corners.
+   */
+  @media (max-width: 640px) {
     .fractal-bg {
-      transition: none;
+      -webkit-mask-image: radial-gradient(ellipse 110% 110% at 50% 50%, #000 55%, transparent 100%);
+      mask-image: radial-gradient(ellipse 110% 110% at 50% 50%, #000 55%, transparent 100%);
     }
   }
 </style>
@@ -42,6 +42,21 @@ const { fill = 0.98 } = Astro.props;
    * stops looking like a fractal and starts looking like grey noise.
    */
   const MAX_DEPTH = 8;
+
+  // One pass of the pen, in seconds. Levels are drawn strictly one after
+  // another, so a bar never appears before the bar it hangs off has reached it.
+  const DRAW_LEVEL = 1.05;
+  const ERASE_LEVEL = 0.55;
+  /** Spread within a level, so each one sweeps across rather than blinking on. */
+  const SWEEP = 0.45;
+  const HOLD = 20;
+  const REST = 0.8;
+  const DRAW_TIME = (MAX_DEPTH + 1) * DRAW_LEVEL + SWEEP;
+  const ERASE_TIME = (MAX_DEPTH + 1) * ERASE_LEVEL + SWEEP;
+  const CYCLE = DRAW_TIME + HOLD + ERASE_TIME + REST;
+
+  /** Length of the brighter nib left at each growing end. */
+  const NIB = 14;
 
   type Seg = { x: number; y: number; len: number; horizontal: boolean };
   type Rgb = [number, number, number];
@@ -71,6 +86,12 @@ const { fill = 0.98 } = Astro.props;
     return null;
   }
 
+  /** Ease in and out, so the pen accelerates away and settles rather than jerking. */
+  function ease(p: number) {
+    const t = p < 0 ? 0 : p > 1 ? 1 : p;
+    return t * t * (3 - 2 * t);
+  }
+
   function initFractalBackground() {
     teardown?.();
     teardown = null;
@@ -83,16 +104,19 @@ const { fill = 0.98 } = Astro.props;
     const root = document.documentElement;
     const fill = Number(canvas.dataset.fill) || 0.98;
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    // Restart the cycle on every init, so arriving on the page — including
+    // navigating back to it — always catches the tree drawing itself.
+    const startedAt = performance.now();
 
     let width = 0;
     let height = 0;
     let rootLen = 0;
     let baseVRatio = 1;
+    let weightBoost = 1;
     let palette = readPalette();
     let rafId = 0;
     let lastFrame = 0;
     let running = false;
-    let revealed = false;
 
     function readPalette(): Palette {
       const styles = getComputedStyle(root);
@@ -100,7 +124,7 @@ const { fill = 0.98 } = Astro.props;
       return {
         from: parseColor(styles.getPropertyValue("--primary")) ?? [131, 25, 230],
         to: parseColor(styles.getPropertyValue("--accent")) ?? [97, 66, 189],
-        alpha: isDark ? 0.5 : 0.36,
+        alpha: isDark ? 0.58 : 0.44,
       };
     }
 
@@ -111,6 +135,7 @@ const { fill = 0.98 } = Astro.props;
       canvas!.width = Math.round(width * dpr);
       canvas!.height = Math.round(height * dpr);
       ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx!.lineCap = "round";
 
       // The tree's vertical extent works out to vRatio times its horizontal
       // one, so matching vRatio to the viewport's aspect is what fits it to the
@@ -122,22 +147,41 @@ const { fill = 0.98 } = Astro.props;
       // axis needs more and let the other overflow — cropping the pattern reads
       // better than leaving a margin around it.
       rootLen = Math.max(width / 2, height / 2 / baseVRatio) * fill;
+      // A phone only ever shows the thin margin around the card, so the little
+      // that is visible has to carry more weight.
+      weightBoost = width <= 640 ? 1.45 : 1;
     }
 
-    function depthStyle(depth: number) {
+    function style(depth: number, boost: number) {
       const k = depth / MAX_DEPTH;
       const [r1, g1, b1] = palette.from;
       const [r2, g2, b2] = palette.to;
       // Every level doubles the bar count while only shrinking each bar by ~30%,
       // so the ink per level still grows. Fading as we descend keeps the trunk
       // legible and leaves the deepest levels as fine texture.
-      const weight = Math.pow(0.82, depth);
+      const alpha = Math.min(0.95, palette.alpha * Math.pow(0.82, depth) * weightBoost * boost);
       return `rgba(${Math.round(r1 + (r2 - r1) * k)}, ${Math.round(g1 + (g2 - g1) * k)}, ${Math.round(
         b1 + (b2 - b1) * k,
-      )}, ${(palette.alpha * weight).toFixed(4)})`;
+      )}, ${alpha.toFixed(4)})`;
     }
 
-    function draw(seconds: number) {
+    /**
+     * How much of a bar at this depth has been drawn, 0 to 1. Levels run
+     * outward on the way in and back inward on the way out, so the tree always
+     * stays connected to its trunk.
+     */
+    function reachAt(depth: number, offset: number, cycleTime: number) {
+      if (cycleTime < DRAW_TIME) {
+        return ease((cycleTime - depth * DRAW_LEVEL - offset * SWEEP) / DRAW_LEVEL);
+      }
+      const held = cycleTime - DRAW_TIME;
+      if (held < HOLD) return 1;
+      const erasing = held - HOLD;
+      if (erasing >= ERASE_TIME) return 0;
+      return 1 - ease((erasing - (MAX_DEPTH - depth) * ERASE_LEVEL - offset * SWEEP) / ERASE_LEVEL);
+    }
+
+    function draw(seconds: number, complete: boolean) {
       ctx!.clearRect(0, 0, width, height);
 
       // An H-tree: every bar sprouts a perpendicular bar centred on each of its
@@ -145,33 +189,63 @@ const { fill = 0.98 } = Astro.props;
       // shrink ratios — at 0.5 the tree exactly tiles the plane, below it the
       // branches pull apart into separate clusters, above it they overlap into a
       // denser weave. `stretch` then trades one axis against the other, so the
-      // cells breathe between wide and tall. Incommensurate periods, so the
-      // figure never repeats a pose.
+      // cells breathe between wide and tall. Both run far slower than a draw
+      // cycle, so each pass of the pen lays down a slightly different figure.
       const contract = 0.5 + 0.055 * Math.sin(seconds * 0.061 + 1.3);
       const stretch = 1 + 0.16 * Math.sin(seconds * 0.041);
       // Ratio applied going horizontal -> vertical, and its partner coming back.
       const vRatio = baseVRatio * stretch;
       const hRatio = contract / vRatio;
 
-      let level: Seg[] = [
-        { x: width / 2, y: height / 2, len: rootLen * (1 + 0.06 * Math.sin(seconds * 0.029)), horizontal: true },
-      ];
+      const cycleTime = seconds % CYCLE;
+      let level: Seg[] = [{ x: width / 2, y: height / 2, len: rootLen, horizontal: true }];
 
       for (let depth = 0; depth <= MAX_DEPTH; depth++) {
+        const nibs: number[] = [];
         ctx!.beginPath();
-        for (const seg of level) {
-          const half = seg.len / 2;
+
+        for (let i = 0; i < level.length; i++) {
+          const seg = level[i];
+          const reach = (seg.len / 2) * (complete ? 1 : reachAt(depth, i / level.length, cycleTime));
+          if (reach <= 0) continue;
+
           if (seg.horizontal) {
-            ctx!.moveTo(seg.x - half, seg.y);
-            ctx!.lineTo(seg.x + half, seg.y);
+            ctx!.moveTo(seg.x - reach, seg.y);
+            ctx!.lineTo(seg.x + reach, seg.y);
           } else {
-            ctx!.moveTo(seg.x, seg.y - half);
-            ctx!.lineTo(seg.x, seg.y + half);
+            ctx!.moveTo(seg.x, seg.y - reach);
+            ctx!.lineTo(seg.x, seg.y + reach);
+          }
+
+          // Both ends of a bar grow outward from its middle, so a bar that is
+          // still moving has two live nibs.
+          if (!complete && reach < seg.len / 2 - 0.5) {
+            const nib = Math.min(NIB, reach);
+            if (seg.horizontal) {
+              nibs.push(seg.x + reach - nib, seg.y, seg.x + reach, seg.y);
+              nibs.push(seg.x - reach + nib, seg.y, seg.x - reach, seg.y);
+            } else {
+              nibs.push(seg.x, seg.y + reach - nib, seg.x, seg.y + reach);
+              nibs.push(seg.x, seg.y - reach + nib, seg.x, seg.y - reach);
+            }
           }
         }
-        ctx!.lineWidth = Math.max(0.5, 2 * Math.pow(0.86, depth));
-        ctx!.strokeStyle = depthStyle(depth);
+
+        const lineWidth = Math.max(0.6, 2 * Math.pow(0.86, depth));
+        ctx!.lineWidth = lineWidth;
+        ctx!.strokeStyle = style(depth, 1);
         ctx!.stroke();
+
+        if (nibs.length) {
+          ctx!.beginPath();
+          for (let n = 0; n < nibs.length; n += 4) {
+            ctx!.moveTo(nibs[n], nibs[n + 1]);
+            ctx!.lineTo(nibs[n + 2], nibs[n + 3]);
+          }
+          ctx!.lineWidth = lineWidth * 1.5;
+          ctx!.strokeStyle = style(depth, 3.2);
+          ctx!.stroke();
+        }
 
         if (depth === MAX_DEPTH) break;
 
@@ -191,11 +265,6 @@ const { fill = 0.98 } = Astro.props;
         if (!next.length) break;
         level = next;
       }
-
-      if (!revealed) {
-        revealed = true;
-        canvas!.classList.add("is-ready");
-      }
     }
 
     function loop(now: number) {
@@ -203,7 +272,7 @@ const { fill = 0.98 } = Astro.props;
       // ~30fps is plenty for motion this slow, and halves the battery cost.
       if (now - lastFrame < 33) return;
       lastFrame = now;
-      draw(now / 1000);
+      draw((now - startedAt) / 1000, false);
     }
 
     function start() {
@@ -221,7 +290,8 @@ const { fill = 0.98 } = Astro.props;
     function render() {
       if (reduceMotion.matches) {
         halt();
-        draw(9);
+        // No pen, just the finished drawing.
+        draw(9, true);
       } else {
         start();
       }
@@ -229,7 +299,7 @@ const { fill = 0.98 } = Astro.props;
 
     function onResize() {
       resize();
-      if (reduceMotion.matches) draw(9);
+      if (reduceMotion.matches) draw(9, true);
     }
 
     function onVisibility() {
@@ -239,7 +309,7 @@ const { fill = 0.98 } = Astro.props;
 
     function onTheme() {
       palette = readPalette();
-      if (reduceMotion.matches) draw(9);
+      if (reduceMotion.matches) draw(9, true);
     }
 
     const themeObserver = new MutationObserver(onTheme);

--- a/src/components/FractalBackground.astro
+++ b/src/components/FractalBackground.astro
@@ -1,13 +1,13 @@
 ---
 interface Props {
-  /** Radius of the fractal's root ring, as a fraction of the viewport diagonal. */
-  radius?: number;
+  /** How much of the viewport the tree spans, 1 meaning edge to edge. */
+  fill?: number;
 }
 
-const { radius = 0.28 } = Astro.props;
+const { fill = 0.98 } = Astro.props;
 ---
 
-<canvas id="fractal-bg" class="fractal-bg" aria-hidden="true" data-radius={radius}></canvas>
+<canvas id="fractal-bg" class="fractal-bg" aria-hidden="true" data-fill={fill}></canvas>
 
 <style>
   .fractal-bg {
@@ -20,8 +20,8 @@ const { radius = 0.28 } = Astro.props;
     opacity: 0;
     transition: opacity 2s ease-in;
     /* Soften the edges so the pattern dissolves rather than stopping at the viewport. */
-    -webkit-mask-image: radial-gradient(circle at 50% 50%, #000 40%, transparent 88%);
-    mask-image: radial-gradient(circle at 50% 50%, #000 40%, transparent 88%);
+    -webkit-mask-image: radial-gradient(ellipse 70% 70% at 50% 50%, #000 15%, transparent 100%);
+    mask-image: radial-gradient(ellipse 70% 70% at 50% 50%, #000 15%, transparent 100%);
   }
 
   .fractal-bg.is-ready {
@@ -36,11 +36,14 @@ const { radius = 0.28 } = Astro.props;
 </style>
 
 <script>
-  const TAU = Math.PI * 2;
-  /** Children spawned per node. Also the rotational symmetry of the whole figure. */
-  const ARMS = 6;
+  /**
+   * Levels of recursion. Each one doubles the bar count while shrinking each bar
+   * by only ~30%, and past here they get too small to read as H's — the tree
+   * stops looking like a fractal and starts looking like grey noise.
+   */
+  const MAX_DEPTH = 8;
 
-  type Node = { x: number; y: number; r: number; a: number };
+  type Seg = { x: number; y: number; len: number; horizontal: boolean };
   type Rgb = [number, number, number];
   type Palette = { from: Rgb; to: Rgb; alpha: number };
 
@@ -78,13 +81,13 @@ const { radius = 0.28 } = Astro.props;
     if (!ctx) return;
 
     const root = document.documentElement;
-    const radiusRatio = Number(canvas.dataset.radius) || 0.28;
+    const fill = Number(canvas.dataset.fill) || 0.98;
     const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
 
     let width = 0;
     let height = 0;
-    let maxDepth = 4;
-    let rootRadius = 0;
+    let rootLen = 0;
+    let baseVRatio = 1;
     let palette = readPalette();
     let rafId = 0;
     let lastFrame = 0;
@@ -97,7 +100,7 @@ const { radius = 0.28 } = Astro.props;
       return {
         from: parseColor(styles.getPropertyValue("--primary")) ?? [131, 25, 230],
         to: parseColor(styles.getPropertyValue("--accent")) ?? [97, 66, 189],
-        alpha: isDark ? 0.55 : 0.4,
+        alpha: isDark ? 0.5 : 0.36,
       };
     }
 
@@ -109,22 +112,26 @@ const { radius = 0.28 } = Astro.props;
       canvas!.height = Math.round(height * dpr);
       ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
 
-      const narrow = Math.min(width, height) < 560;
-      // Branching is 6^depth, so shrink the tree on small screens.
-      maxDepth = narrow ? 3 : 4;
-      // On a phone the card covers most of the viewport, so the figure has to
-      // run off the edges to leave anything worth looking at around it.
-      rootRadius = Math.hypot(width, height) * radiusRatio * (narrow ? 1.5 : 1);
+      // The tree's vertical extent works out to vRatio times its horizontal
+      // one, so matching vRatio to the viewport's aspect is what fits it to the
+      // screen. Clamped, because a phone's aspect would otherwise stretch the
+      // cells into thin vertical slots with no H left to see.
+      const aspect = Math.min(Math.max(height / width, 0.6), 1.6);
+      baseVRatio = aspect ** 0.8;
+      // The trunk's half-extent converges on its own length. Take whichever
+      // axis needs more and let the other overflow — cropping the pattern reads
+      // better than leaving a margin around it.
+      rootLen = Math.max(width / 2, height / 2 / baseVRatio) * fill;
     }
 
     function depthStyle(depth: number) {
-      const k = maxDepth === 0 ? 0 : depth / maxDepth;
+      const k = depth / MAX_DEPTH;
       const [r1, g1, b1] = palette.from;
       const [r2, g2, b2] = palette.to;
-      // Each level has 6x more rings than the last, so it has to fade
-      // proportionally or the leaves swamp everything above them. The root is
-      // held back separately — on its own it reads as a hard hoop around the page.
-      const weight = depth === 0 ? 0.72 : Math.pow(0.62, depth);
+      // Every level doubles the bar count while only shrinking each bar by ~30%,
+      // so the ink per level still grows. Fading as we descend keeps the trunk
+      // legible and leaves the deepest levels as fine texture.
+      const weight = Math.pow(0.82, depth);
       return `rgba(${Math.round(r1 + (r2 - r1) * k)}, ${Math.round(g1 + (g2 - g1) * k)}, ${Math.round(
         b1 + (b2 - b1) * k,
       )}, ${(palette.alpha * weight).toFixed(4)})`;
@@ -133,44 +140,55 @@ const { radius = 0.28 } = Astro.props;
     function draw(seconds: number) {
       ctx!.clearRect(0, 0, width, height);
 
-      // Incommensurate periods, so the figure keeps morphing without ever
-      // returning to a pose you've already seen. `spread` does most of the
-      // visible work, sliding each ring of children in and out along their
-      // parent's radius so the rosette breathes between tight and open. Keeping
-      // spread + childScale near 1 is what holds the figure together: let the
-      // children clear their parent's rim and the levels splay apart into a
-      // sparse scatter of unrelated circles.
-      const childScale = 0.36 + 0.05 * Math.sin(seconds * 0.083);
-      const spread = 0.6 + 0.1 * Math.sin(seconds * 0.061 + 1.3);
-      const twist = 0.3 * Math.sin(seconds * 0.047 + 0.6);
-      const spin = seconds * 0.017;
+      // An H-tree: every bar sprouts a perpendicular bar centred on each of its
+      // ends, half the area each time. `contract` is the product of the two
+      // shrink ratios — at 0.5 the tree exactly tiles the plane, below it the
+      // branches pull apart into separate clusters, above it they overlap into a
+      // denser weave. `stretch` then trades one axis against the other, so the
+      // cells breathe between wide and tall. Incommensurate periods, so the
+      // figure never repeats a pose.
+      const contract = 0.5 + 0.055 * Math.sin(seconds * 0.061 + 1.3);
+      const stretch = 1 + 0.16 * Math.sin(seconds * 0.041);
+      // Ratio applied going horizontal -> vertical, and its partner coming back.
+      const vRatio = baseVRatio * stretch;
+      const hRatio = contract / vRatio;
 
-      let level: Node[] = [{ x: width / 2, y: height / 2, r: rootRadius, a: spin }];
+      let level: Seg[] = [
+        { x: width / 2, y: height / 2, len: rootLen * (1 + 0.06 * Math.sin(seconds * 0.029)), horizontal: true },
+      ];
 
-      for (let depth = 0; depth <= maxDepth; depth++) {
+      for (let depth = 0; depth <= MAX_DEPTH; depth++) {
         ctx!.beginPath();
-        for (const node of level) {
-          ctx!.moveTo(node.x + node.r, node.y);
-          ctx!.arc(node.x, node.y, node.r, 0, TAU);
+        for (const seg of level) {
+          const half = seg.len / 2;
+          if (seg.horizontal) {
+            ctx!.moveTo(seg.x - half, seg.y);
+            ctx!.lineTo(seg.x + half, seg.y);
+          } else {
+            ctx!.moveTo(seg.x, seg.y - half);
+            ctx!.lineTo(seg.x, seg.y + half);
+          }
         }
-        ctx!.lineWidth = Math.max(0.5, 1.4 * Math.pow(0.78, depth));
+        ctx!.lineWidth = Math.max(0.5, 2 * Math.pow(0.86, depth));
         ctx!.strokeStyle = depthStyle(depth);
         ctx!.stroke();
 
-        if (depth === maxDepth || level[0].r * childScale < 1.2) break;
+        if (depth === MAX_DEPTH) break;
 
-        const next: Node[] = [];
-        for (const node of level) {
-          for (let i = 0; i < ARMS; i++) {
-            const a = node.a + (i * TAU) / ARMS;
-            next.push({
-              x: node.x + Math.cos(a) * node.r * spread,
-              y: node.y + Math.sin(a) * node.r * spread,
-              r: node.r * childScale,
-              a: a + twist,
-            });
+        const next: Seg[] = [];
+        for (const seg of level) {
+          const half = seg.len / 2;
+          const len = seg.len * (seg.horizontal ? vRatio : hRatio);
+          if (len < 1) continue;
+          if (seg.horizontal) {
+            next.push({ x: seg.x - half, y: seg.y, len, horizontal: false });
+            next.push({ x: seg.x + half, y: seg.y, len, horizontal: false });
+          } else {
+            next.push({ x: seg.x, y: seg.y - half, len, horizontal: true });
+            next.push({ x: seg.x, y: seg.y + half, len, horizontal: true });
           }
         }
+        if (!next.length) break;
         level = next;
       }
 

--- a/src/components/FractalBackground.astro
+++ b/src/components/FractalBackground.astro
@@ -1,0 +1,251 @@
+---
+interface Props {
+  /** Radius of the fractal's root ring, as a fraction of the viewport diagonal. */
+  radius?: number;
+}
+
+const { radius = 0.28 } = Astro.props;
+---
+
+<canvas id="fractal-bg" class="fractal-bg" aria-hidden="true" data-radius={radius}></canvas>
+
+<style>
+  .fractal-bg {
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 2s ease-in;
+    /* Soften the edges so the pattern dissolves rather than stopping at the viewport. */
+    -webkit-mask-image: radial-gradient(circle at 50% 50%, #000 40%, transparent 88%);
+    mask-image: radial-gradient(circle at 50% 50%, #000 40%, transparent 88%);
+  }
+
+  .fractal-bg.is-ready {
+    opacity: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .fractal-bg {
+      transition: none;
+    }
+  }
+</style>
+
+<script>
+  const TAU = Math.PI * 2;
+  /** Children spawned per node. Also the rotational symmetry of the whole figure. */
+  const ARMS = 6;
+
+  type Node = { x: number; y: number; r: number; a: number };
+  type Rgb = [number, number, number];
+  type Palette = { from: Rgb; to: Rgb; alpha: number };
+
+  let teardown: (() => void) | null = null;
+
+  function parseColor(value: string): Rgb | null {
+    const raw = value.trim();
+    if (raw.startsWith("#")) {
+      const hex =
+        raw.length === 4
+          ? raw
+              .slice(1)
+              .split("")
+              .map((c) => c + c)
+              .join("")
+          : raw.slice(1, 7);
+      const n = Number.parseInt(hex, 16);
+      if (Number.isNaN(n)) return null;
+      return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+    }
+    const parts = raw.match(/-?\d*\.?\d+/g);
+    if (parts && parts.length >= 3) {
+      return [Number(parts[0]), Number(parts[1]), Number(parts[2])];
+    }
+    return null;
+  }
+
+  function initFractalBackground() {
+    teardown?.();
+    teardown = null;
+
+    const canvas = document.getElementById("fractal-bg") as HTMLCanvasElement | null;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const root = document.documentElement;
+    const radiusRatio = Number(canvas.dataset.radius) || 0.28;
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    let width = 0;
+    let height = 0;
+    let maxDepth = 4;
+    let rootRadius = 0;
+    let palette = readPalette();
+    let rafId = 0;
+    let lastFrame = 0;
+    let running = false;
+    let revealed = false;
+
+    function readPalette(): Palette {
+      const styles = getComputedStyle(root);
+      const isDark = root.getAttribute("data-theme") === "dark";
+      return {
+        from: parseColor(styles.getPropertyValue("--primary")) ?? [131, 25, 230],
+        to: parseColor(styles.getPropertyValue("--accent")) ?? [97, 66, 189],
+        alpha: isDark ? 0.55 : 0.4,
+      };
+    }
+
+    function resize() {
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      width = window.innerWidth;
+      height = window.innerHeight;
+      canvas!.width = Math.round(width * dpr);
+      canvas!.height = Math.round(height * dpr);
+      ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+      const narrow = Math.min(width, height) < 560;
+      // Branching is 6^depth, so shrink the tree on small screens.
+      maxDepth = narrow ? 3 : 4;
+      // On a phone the card covers most of the viewport, so the figure has to
+      // run off the edges to leave anything worth looking at around it.
+      rootRadius = Math.hypot(width, height) * radiusRatio * (narrow ? 1.5 : 1);
+    }
+
+    function depthStyle(depth: number) {
+      const k = maxDepth === 0 ? 0 : depth / maxDepth;
+      const [r1, g1, b1] = palette.from;
+      const [r2, g2, b2] = palette.to;
+      // Each level has 6x more rings than the last, so it has to fade
+      // proportionally or the leaves swamp everything above them. The root is
+      // held back separately — on its own it reads as a hard hoop around the page.
+      const weight = depth === 0 ? 0.72 : Math.pow(0.62, depth);
+      return `rgba(${Math.round(r1 + (r2 - r1) * k)}, ${Math.round(g1 + (g2 - g1) * k)}, ${Math.round(
+        b1 + (b2 - b1) * k,
+      )}, ${(palette.alpha * weight).toFixed(4)})`;
+    }
+
+    function draw(seconds: number) {
+      ctx!.clearRect(0, 0, width, height);
+
+      // Incommensurate periods, so the figure keeps morphing without ever
+      // returning to a pose you've already seen. `spread` does most of the
+      // visible work, sliding each ring of children in and out along their
+      // parent's radius so the rosette breathes between tight and open. Keeping
+      // spread + childScale near 1 is what holds the figure together: let the
+      // children clear their parent's rim and the levels splay apart into a
+      // sparse scatter of unrelated circles.
+      const childScale = 0.36 + 0.05 * Math.sin(seconds * 0.083);
+      const spread = 0.6 + 0.1 * Math.sin(seconds * 0.061 + 1.3);
+      const twist = 0.3 * Math.sin(seconds * 0.047 + 0.6);
+      const spin = seconds * 0.017;
+
+      let level: Node[] = [{ x: width / 2, y: height / 2, r: rootRadius, a: spin }];
+
+      for (let depth = 0; depth <= maxDepth; depth++) {
+        ctx!.beginPath();
+        for (const node of level) {
+          ctx!.moveTo(node.x + node.r, node.y);
+          ctx!.arc(node.x, node.y, node.r, 0, TAU);
+        }
+        ctx!.lineWidth = Math.max(0.5, 1.4 * Math.pow(0.78, depth));
+        ctx!.strokeStyle = depthStyle(depth);
+        ctx!.stroke();
+
+        if (depth === maxDepth || level[0].r * childScale < 1.2) break;
+
+        const next: Node[] = [];
+        for (const node of level) {
+          for (let i = 0; i < ARMS; i++) {
+            const a = node.a + (i * TAU) / ARMS;
+            next.push({
+              x: node.x + Math.cos(a) * node.r * spread,
+              y: node.y + Math.sin(a) * node.r * spread,
+              r: node.r * childScale,
+              a: a + twist,
+            });
+          }
+        }
+        level = next;
+      }
+
+      if (!revealed) {
+        revealed = true;
+        canvas!.classList.add("is-ready");
+      }
+    }
+
+    function loop(now: number) {
+      rafId = requestAnimationFrame(loop);
+      // ~30fps is plenty for motion this slow, and halves the battery cost.
+      if (now - lastFrame < 33) return;
+      lastFrame = now;
+      draw(now / 1000);
+    }
+
+    function start() {
+      if (running || reduceMotion.matches) return;
+      running = true;
+      lastFrame = 0;
+      rafId = requestAnimationFrame(loop);
+    }
+
+    function halt() {
+      running = false;
+      cancelAnimationFrame(rafId);
+    }
+
+    function render() {
+      if (reduceMotion.matches) {
+        halt();
+        draw(9);
+      } else {
+        start();
+      }
+    }
+
+    function onResize() {
+      resize();
+      if (reduceMotion.matches) draw(9);
+    }
+
+    function onVisibility() {
+      if (document.hidden) halt();
+      else render();
+    }
+
+    function onTheme() {
+      palette = readPalette();
+      if (reduceMotion.matches) draw(9);
+    }
+
+    const themeObserver = new MutationObserver(onTheme);
+    themeObserver.observe(root, { attributeFilter: ["data-theme"] });
+    window.addEventListener("resize", onResize);
+    document.addEventListener("visibilitychange", onVisibility);
+    reduceMotion.addEventListener("change", render);
+
+    resize();
+    render();
+
+    teardown = () => {
+      halt();
+      themeObserver.disconnect();
+      window.removeEventListener("resize", onResize);
+      document.removeEventListener("visibilitychange", onVisibility);
+      reduceMotion.removeEventListener("change", render);
+    };
+  }
+
+  initFractalBackground();
+  document.addEventListener("astro:after-swap", initFractalBackground);
+  document.addEventListener("astro:before-swap", () => {
+    teardown?.();
+    teardown = null;
+  });
+</script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,18 +1,21 @@
 ---
 import Base from "../layouts/Base.astro";
 import Copyright from "../components/Copyright.astro";
+import FractalBackground from "../components/FractalBackground.astro";
 import ThemeButton from "../components/ThemeButton.astro";
 import { Image } from "astro:assets";
 import meImage from "../../public/me.jpg";
 ---
 
 <Base>
+  <FractalBackground />
+
   {/* Home theme button - fixed position */}
   <div id="home-theme-btn" class="fixed right-4 top-4 z-[1000] flex justify-end">
     <ThemeButton position="bottom" />
   </div>
 
-  <div class="mt-16 flex items-center justify-center sm:absolute sm:top-0 sm:right-0 sm:bottom-0 sm:left-0 sm:m-auto sm:mt-0">
+  <div class="relative z-10 mt-16 flex items-center justify-center sm:absolute sm:top-0 sm:right-0 sm:bottom-0 sm:left-0 sm:m-auto sm:mt-0">
     <div class="w-[85%] text-center sm:w-fit">
       <div class="background-and-shadow bg-background-secondary rounded-xl border-b-2 border-gray-300 px-6 pt-8 pb-6 shadow-lg dark:border-none dark:shadow-none">
         <div class="fade-in three mx-auto mb-4 h-36 w-36 overflow-hidden rounded-full">


### PR DESCRIPTION
Draws a six-fold recursive rosette of circles on a fixed canvas behind the
home page card. Each ring spawns six children scaled and rotated from its
own frame, four levels deep; three slow sine waves with incommensurate
periods drive the child scale, the radial spread and the per-level twist, so
the figure keeps reshaping itself and never repeats a pose.

Kept deliberately quiet: colours come from the theme's --primary/--accent so
it follows light/dark, alpha falls off by depth to stop the ~1300 leaf rings
swamping the levels above, and a radial mask dissolves the edges.

Rings are batched into one stroke per depth, the loop is capped at ~30fps and
pauses on tab hide, recursion depth drops on small screens, and
prefers-reduced-motion gets a single static frame instead of the animation.
The canvas is torn down and re-initialised around ClientRouter swaps.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PY1jqwvq2HdzMB1vQA7ciZ