### PR TITLE
Correct deployment docs and document PR previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,33 @@ Blog posts live in `src/content/blog/` as `.md` or `.mdx` files.
 
 ## Deployment
 
-The site is deployed to Cloudflare Pages. A GitHub Actions workflow runs on push/PR to `main`, which installs dependencies and runs `pnpm build`.
+The site is deployed to **Cloudflare Workers** as a static assets Worker —
+`wrangler.jsonc` points the Worker at the `dist/` build output.
+
+Deploys run through [Workers Builds](https://developers.cloudflare.com/workers/ci-cd/builds/git-integration/),
+Cloudflare's Git integration, which is connected to this repository. Cloudflare
+builds every push itself; there is no deploy step in GitHub Actions. The Actions
+workflows only lint (`lint.yaml`) and build (`build.yaml`) on push/PR to `main`
+as a check.
+
+### PR previews
+
+Every pull request gets a live preview automatically — nothing to configure.
+Cloudflare builds the branch and the `cloudflare-workers-and-pages` bot posts a
+comment on the PR with two links:
+
+| Link | Points at | Use it for |
+|---|---|---|
+| **Commit Preview URL** | One specific commit, immutable | Comparing two builds of the same PR |
+| **Branch Preview URL** | Latest commit on the branch | Sharing a link that stays current as you push |
+
+The URLs look like this:
+
+```
+https://<commit-hash>-kylejs-site.k-830.workers.dev     # commit preview
+https://<branch-name>-kylejs-site.k-830.workers.dev     # branch preview
+```
+
+Previews are versions uploaded without production traffic routed to them, so
+opening one never affects the live site. The build logs are linked from the same
+comment, which is the place to look when a preview doesn't come up.


### PR DESCRIPTION
Docs-only. One file changed: `README.md`.

## Why

This started out as "add Cloudflare PR previews," but previews already work — Cloudflare's Workers Builds Git integration is connected and posts a preview URL on every PR, including [on this one](https://github.com/ky1ejs/kylejs-site/pull/457#issuecomment-5198423217). The original workflow in this branch would have been a second, parallel preview pipeline, so it's been dropped.

What was actually broken is the README, and it's most of why the existing setup looked absent:

- It said the site deploys to **Cloudflare Pages**. It deploys to **Cloudflare Workers** as a static-assets Worker (`wrangler.jsonc`).
- It described CI as "installs dependencies and runs `pnpm build`", implying Actions deploys the site. Actions only lints and builds as a check — Cloudflare builds and deploys.
- It didn't mention PR previews at all.

## What changed

The Deployment section now describes the real setup: Workers Builds as the deploy path, and a PR previews subsection covering the bot comment, the difference between the **Commit Preview URL** (immutable, good for comparing two builds of a PR) and the **Branch Preview URL** (follows the branch), the URL shape, and where the build logs live when a preview doesn't come up.

## Verification

Prose only — no code, config, or dependency changes, so nothing to run. The behaviour described was confirmed against the bot comments on this PR and on #454, and the Cloudflare deploy check on both.

Superseded and removed from the branch: the `preview.yaml` workflow, the `wrangler` devDependency, and the `preview_urls` addition to `wrangler.jsonc`.