### PR TITLE
Add SessionStart hook to install Git LFS in Claude Code web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+#
+# The repo stores all images (png/jpg/webp/ico) and 3mf models in Git LFS, but the
+# remote container ships without git-lfs. Without it the working tree only contains
+# ~130 byte LFS pointer files, so `astro build` fails as soon as Sharp tries to
+# process an "image" that is really a text pointer.
+#
+# This hook installs git-lfs, materialises the real binaries, and installs node deps.
+set -euo pipefail
+
+# Only run in Claude Code on the web - local machines already have their own setup.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(dirname "$0")/../..}"
+
+if ! command -v git-lfs >/dev/null 2>&1; then
+  echo "Installing git-lfs..."
+  SUDO=""
+  if [ "$(id -u)" -ne 0 ]; then
+    SUDO="sudo"
+  fi
+  export DEBIAN_FRONTEND=noninteractive
+  # Third-party PPAs in the base image are blocked by the egress proxy and make
+  # `apt-get update` noisy/non-zero; the Ubuntu archive we need still refreshes.
+  $SUDO apt-get update -qq || true
+  $SUDO apt-get install -y -qq git-lfs
+fi
+
+# Register the LFS filters for this repo only (idempotent).
+git lfs install --local
+
+# Replace pointer files with the real objects. --include= --exclude= overrides any
+# repo/global include-exclude filters so every tracked object is fetched.
+echo "Fetching Git LFS objects..."
+git lfs pull --include="*" --exclude=""
+
+# Sanity check: a materialised PNG must not still be an LFS pointer.
+sample="$(git lfs ls-files -n | head -1 || true)"
+if [ -n "$sample" ] && [ -f "$sample" ] && head -c 40 "$sample" | grep -q "git-lfs.github.com"; then
+  echo "WARNING: $sample is still a Git LFS pointer - image builds will fail." >&2
+fi
+
+echo "Installing node dependencies..."
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+corepack enable >/dev/null 2>&1 || true
+pnpm install
+
+echo "Session setup complete."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Problem

`.gitattributes` routes all images through Git LFS (`*.png`, `*.jpg`, `*.jpeg`, `*.webp`, `*.ico`, `*.3mf`). The Claude Code on the web container ships **without `git-lfs`**, so those 26 files check out as ~130-byte pointer files rather than images.

`pnpm build` then fails as soon as Sharp touches one:

```
[NoImageMetadata] [astro:assets:esm] Could not load /public/me.jpg
  (imported by src/pages/index.astro): Could not process image metadata
```

The result is that web sessions can't build, preview, or verify any change to the site.

CI already handles this — `.github/workflows/build.yaml` sets `lfs: true` on checkout. Web sessions had no equivalent.

## Changes

- **`.claude/hooks/session-start.sh`** (new) — installs `git-lfs` via apt, runs `git lfs install --local` and `git lfs pull --include="*" --exclude=""`, sanity-checks that a tracked file is no longer a pointer, then runs `pnpm install`.
- **`.claude/settings.json`** (new) — registers the script as a `SessionStart` hook.

Behavioural details:

- Guarded on `CLAUDE_CODE_REMOTE` so it is a silent no-op on local machines.
- Idempotent — skips the apt install when `git-lfs` is already present, and is safe to re-run.
- `apt-get update` failures are tolerated: unrelated third-party PPAs in the base image are blocked by the egress proxy, but the Ubuntu archive still refreshes.
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` keeps the dependency install non-interactive.
- Runs synchronously, so dependencies and LFS objects are guaranteed present before the session starts. This costs some startup latency; it can be switched to async mode if that trade-off is preferred.

Nothing outside `.claude/` changes — no application code, config, or dependencies are touched.

## Validation

The container was first torn back down to a fresh state (git-lfs removed, pointer files restored) so these are genuine before/after results rather than a warm cache.

- ✅ Hook ran clean from the torn-down state, exit 0; re-ran twice to confirm idempotency.
- ✅ `CLAUDE_CODE_REMOTE` guard verified — exits 0 with no output when unset.
- ✅ `pnpm build` **failed** with `NoImageMetadata` before the hook, and **passed** after: 9 pages built, all 15 images genuinely processed (`me.jpg` 286kB → 18kB webp).
- ✅ `pnpm exec eslint src/pages/index.astro` — exit 0.

⚠️ This repo has no test suite (no `test` script, no `*.test.*` / `*.spec.*` files), so `pnpm build` and `pnpm lint` were used for validation — the same commands the two CI workflows run. The hook needs no changes if tests are added later.

Note: this only takes effect for future web sessions once merged to `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjcrwwLLeuy27JdWvLi4Xz)_