### PR TITLE
Stand up the site: areas home page + projects page

### DIFF
--- a/src/components/AreaBand.astro
+++ b/src/components/AreaBand.astro
@@ -1,0 +1,100 @@
+---
+import AreaMark from "./AreaMark.astro";
+import AreaMedia from "./AreaMedia.astro";
+import type { CollectionEntry } from "astro:content";
+
+interface Props {
+  area: CollectionEntry<"areas">;
+  /** Alternating bands get the secondary background, for scroll rhythm. */
+  alt: boolean;
+}
+
+const { area, alt } = Astro.props;
+const { title, mark, meta, why, chain, media, items } = area.data;
+
+// "side" puts the images beside the items; every other layout stacks them above.
+const isSide = media.layout === "side" && media.images.length > 0;
+---
+
+<section
+  id={area.id}
+  class:list={[
+    "scroll-mt-24 px-6 py-7 sm:px-8",
+    alt ? "bg-background-secondary" : "",
+  ]}
+>
+  <div class="mx-auto flex max-w-[800px] gap-4 sm:gap-6">
+    <AreaMark name={mark} class="text-primary h-11 w-11 shrink-0 sm:h-14 sm:w-14" />
+
+    <div class="min-w-0 flex-1">
+      <div class="flex items-baseline justify-between gap-3">
+        <h2 class="m-0 text-2xl font-extrabold tracking-tight">{title}</h2>
+        {meta && <span class="text-muted text-xs tracking-widest uppercase">{meta}</span>}
+      </div>
+
+      <p class="text-muted mt-1 mb-3 max-w-[52ch] text-sm leading-relaxed">{why}</p>
+
+      {
+        chain.length > 0 && (
+          <div class="mb-3 flex flex-wrap items-center gap-1.5">
+            {chain.map((step, i) => (
+              <>
+                {i > 0 && <span class="text-muted text-xs">&rarr;</span>}
+                <span
+                  class:list={[
+                    "rounded border px-2 py-0.5 text-[10px] tracking-wider",
+                    step.code
+                      ? "border-primary text-primary"
+                      : "border-muted/40 text-muted",
+                  ]}
+                >
+                  {step.label}
+                </span>
+              </>
+            ))}
+          </div>
+        )
+      }
+
+      <div class:list={[isSide && "grid items-start gap-4 sm:grid-cols-2"]}>
+        <AreaMedia layout={media.layout} images={media.images} />
+
+        {
+          items.length > 0 && (
+            <ul class="m-0 list-none p-0">
+              {items.map((item) => (
+                <li class="border-muted/25 border-b py-2 last:border-b-0">
+                  <span class="flex flex-wrap items-baseline gap-x-2">
+                    <span
+                      class:list={[
+                        "inline-flex items-center gap-1 rounded-full border px-2 py-[1px] text-[9px] tracking-widest uppercase",
+                        item.writing
+                          ? "border-primary text-primary"
+                          : "border-muted/50 text-muted",
+                      ]}
+                    >
+                      {item.writing && <AreaMark name="pen" class="h-2.5 w-2.5" />}
+                      {item.kind}
+                    </span>
+                    {item.href ? (
+                      <a class="font-semibold no-underline hover:underline" href={item.href}>
+                        {item.title}
+                      </a>
+                    ) : (
+                      <span class="font-semibold">{item.title}</span>
+                    )}
+                  </span>
+                  {item.desc && (
+                    <span class="text-muted mt-0.5 block text-sm leading-snug">
+                      {item.desc}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )
+        }
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/components/AreaCompact.astro
+++ b/src/components/AreaCompact.astro
@@ -1,0 +1,19 @@
+---
+import AreaMark from "./AreaMark.astro";
+import type { CollectionEntry } from "astro:content";
+
+interface Props {
+  area: CollectionEntry<"areas">;
+}
+
+const { area } = Astro.props;
+const { title, mark, why } = area.data;
+---
+
+<div id={area.id} class="bg-background-secondary flex scroll-mt-24 gap-3 rounded-xl p-4">
+  <AreaMark name={mark} class="text-primary h-7 w-7 shrink-0" />
+  <div class="min-w-0">
+    <h2 class="m-0 text-base font-bold tracking-tight">{title}</h2>
+    <p class="text-muted mt-0.5 mb-0 text-sm leading-snug">{why}</p>
+  </div>
+</div>

--- a/src/components/AreaMark.astro
+++ b/src/components/AreaMark.astro
@@ -1,0 +1,22 @@
+---
+import { markPaths, type MarkName } from "../lib/area-marks";
+
+interface Props {
+  name: MarkName;
+  class?: string;
+}
+
+const { name, class: className } = Astro.props;
+---
+
+<svg
+  class={className}
+  viewBox="0 0 64 64"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+  set:html={markPaths[name]}
+/>

--- a/src/components/AreaMedia.astro
+++ b/src/components/AreaMedia.astro
@@ -1,0 +1,60 @@
+---
+/**
+ * Renders an area's images according to its `media.layout`.
+ * An image without a `src` becomes a labelled placeholder, so every layout is
+ * complete before the photography exists.
+ */
+interface Image {
+  src?: string;
+  alt: string;
+  label?: string;
+}
+
+interface Props {
+  layout: "grid" | "wide" | "side" | "hero";
+  images: Image[];
+}
+
+const { layout, images } = Astro.props;
+
+const heights: Record<Props["layout"], string> = {
+  grid: "h-24 sm:h-28",
+  wide: "h-32 sm:h-40",
+  side: "h-28 sm:h-32",
+  hero: "h-48 sm:h-64",
+};
+
+const wrappers: Record<Props["layout"], string> = {
+  grid: "grid grid-cols-3 gap-2",
+  wide: "grid grid-cols-1 gap-2",
+  side: "grid grid-cols-1 gap-2",
+  hero: "grid grid-cols-1 gap-2",
+};
+
+const height = heights[layout];
+---
+
+{
+  images.length > 0 && (
+    <div class={`${wrappers[layout]} mb-3`}>
+      {images.map((image) =>
+        image.src ? (
+          <img
+            src={image.src}
+            alt={image.alt}
+            loading="lazy"
+            class={`${height} w-full rounded-lg object-cover`}
+          />
+        ) : (
+          <div
+            class={`${height} border-muted/60 text-muted flex w-full items-center justify-center rounded-lg border border-dashed p-2 text-center`}
+          >
+            <span class="text-[10px] tracking-widest uppercase">
+              {image.label ?? image.alt}
+            </span>
+          </div>
+        )
+      )}
+    </div>
+  )
+}

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -1,0 +1,82 @@
+---
+interface Props {
+  title: string;
+  description: string;
+  repo?: string;
+  url?: string;
+  status: "active" | "shipped" | "experiment" | "archived";
+  year?: number;
+}
+
+const { title, description, repo, url, status, year } = Astro.props;
+
+const repoUrl = repo ? `https://github.com/${repo}` : undefined;
+const primaryUrl = url ?? repoUrl;
+
+const statusLabel: Record<Props["status"], string> = {
+  active: "Active",
+  shipped: "Shipped",
+  experiment: "Experiment",
+  archived: "Archived",
+};
+
+const statusClass: Record<Props["status"], string> = {
+  active: "border-primary text-primary",
+  shipped: "border-muted text-muted",
+  experiment: "border-accent text-accent",
+  archived: "border-muted text-muted opacity-70",
+};
+---
+
+<div class="border-muted/30 border-b py-4 last:border-b-0">
+  <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+    {
+      primaryUrl ? (
+        <a
+          class="hover:text-primary text-lg font-semibold no-underline"
+          href={primaryUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {title}
+        </a>
+      ) : (
+        <span class="text-lg font-semibold">{title}</span>
+      )
+    }
+    <span
+      class={`rounded-full border px-2 py-[1px] text-[10px] tracking-wider uppercase ${statusClass[status]}`}
+    >
+      {statusLabel[status]}
+    </span>
+    {year && <span class="text-muted text-xs">{year}</span>}
+  </div>
+
+  <p class="text-text-950 mt-1 mb-0">{description}</p>
+
+  <div class="mt-1 flex flex-wrap gap-x-4 text-sm">
+    {
+      url && repoUrl && (
+        <a href={repoUrl} target="_blank" rel="noopener noreferrer">
+          Source
+        </a>
+      )
+    }
+    {
+      !url && repoUrl && (
+        <a href={repoUrl} target="_blank" rel="noopener noreferrer">
+          GitHub
+        </a>
+      )
+    }
+    {
+      url && (
+        <a href={url} target="_blank" rel="noopener noreferrer">
+          Visit site
+        </a>
+      )
+    }
+  </div>
+
+  <slot />
+</div>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -32,4 +32,67 @@ const projects = defineCollection({
   }),
 });
 
-export const collections = { blog, projects };
+/**
+ * Areas are the things Kyle actually does. They drive the home page.
+ *
+ * Layout is deliberately a content decision, not a code one — promoting an area
+ * or a great photo means editing frontmatter here, never touching a component:
+ *   - `display`      band (full width, with items) or compact (small card)
+ *   - `media.layout` how this area's images are arranged; "hero" is the escape
+ *                    hatch for an image good enough to carry the whole section
+ * An image with no `src` renders as a marked placeholder, so the page is
+ * complete and shippable before any photography exists.
+ */
+const areas = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/areas" }),
+  schema: z.object({
+    title: z.string(),
+    mark: z.enum([
+      "code", "printer", "chip", "keyboard",
+      "coffee", "camera", "fish", "mountain", "weight",
+    ]),
+    /** Short label for the sticky rail. Falls back to `title` when omitted. */
+    railLabel: z.string().optional(),
+    /** Lower sorts first. Kyle's own ranking. */
+    order: z.number(),
+    display: z.enum(["band", "compact"]).default("compact"),
+    /** Small right-aligned label, e.g. "29 designs". */
+    meta: z.string().optional(),
+    /** The one-line "why this is me". */
+    why: z.string(),
+    /** Escalation chain — plain steps, `code: true` for the ones that became software. */
+    chain: z
+      .array(z.object({ label: z.string(), code: z.boolean().default(false) }))
+      .default([]),
+    media: z
+      .object({
+        layout: z.enum(["grid", "wide", "side", "hero"]).default("grid"),
+        images: z
+          .array(
+            z.object({
+              /** Path under /public. Omit to render a placeholder slot. */
+              src: z.string().optional(),
+              alt: z.string(),
+              label: z.string().optional(),
+            })
+          )
+          .default([]),
+      })
+      .default({ layout: "grid", images: [] }),
+    items: z
+      .array(
+        z.object({
+          /** Repo, Post, Site, Print… shown as a small pill. */
+          kind: z.string(),
+          title: z.string(),
+          desc: z.string().optional(),
+          href: z.string().optional(),
+          /** Marks it with the pen — writing runs through every area. */
+          writing: z.boolean().default(false),
+        })
+      )
+      .default([]),
+  }),
+});
+
+export const collections = { blog, projects, areas };

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -12,4 +12,24 @@ const blog = defineCollection({
   }),
 });
 
-export const collections = { blog };
+const projects = defineCollection({
+  loader: glob({ pattern: "**/*.md", base: "./src/content/projects" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    group: z.enum(["espresso", "apps", "tools", "keyboards", "workshop"]),
+    /** GitHub repo as "owner/name". Omit for projects with no public repo. */
+    repo: z.string().optional(),
+    /** Live site, if there is one. */
+    url: z.string().url().optional(),
+    /** Year last worked on. Omitted where it isn't known rather than guessed. */
+    year: z.number().int().optional(),
+    status: z.enum(["active", "shipped", "experiment", "archived"]).default("shipped"),
+    /** Featured projects surface on the home page. */
+    featured: z.boolean().default(false),
+    /** Lower sorts first within a group. */
+    order: z.number().default(50),
+  }),
+});
+
+export const collections = { blog, projects };

--- a/src/content/areas/3d-printing.md
+++ b/src/content/areas/3d-printing.md
@@ -1,0 +1,31 @@
+---
+title: "3D printing"
+mark: printer
+railLabel: "Printing"
+order: 2
+display: band
+meta: "29 designs"
+why: "A lockdown hobby that got a Bambu X1C involved. Gridfinity everything, Skadis mounts, and a 10\" rack for the network gear."
+media:
+  layout: grid
+  images:
+    - alt: "A 3D print"
+      label: "Print"
+      # src: /areas/3d-printing-1.jpg
+    - alt: "A 3D print"
+      label: "Print"
+      # src: /areas/3d-printing-1.jpg
+    - alt: "A 3D print"
+      label: "Print"
+      # src: /areas/3d-printing-1.jpg
+items:
+  - kind: "Post"
+    title: "3D Printed Under-Desk MacBook Mount"
+    desc: "With the .3mf, so you can print it yourself."
+    href: "/posts/3d-printed-macbook-desk-mount"
+    writing: true
+  - kind: "Repo"
+    title: "3d-printer-profiles"
+    desc: "My profiles, if you want to skip the dialling in."
+    href: "https://github.com/ky1ejs/3d-printer-profiles"
+---

--- a/src/content/areas/coding.md
+++ b/src/content/areas/coding.md
@@ -1,0 +1,30 @@
+---
+title: "Coding"
+mark: code
+order: 1
+display: band
+meta: "12 repos"
+why: "The day job, and then most of the evenings too. Lately: agents, and what they do to the way a team works."
+media:
+  layout: grid
+  images: []
+items:
+  - kind: "Post"
+    title: "Multi-agent spec review"
+    desc: "Using sub-agents to review and iterate on specs."
+    href: "/posts/multi-agent-spec-review"
+    writing: true
+  - kind: "Post"
+    title: "Remote Agents"
+    desc: "Exploring the concept of Remote Agents in AI development."
+    href: "/posts/remote-agents"
+    writing: true
+  - kind: "Repo"
+    title: "Jim"
+    desc: "An iOS app for tracking your gym workouts."
+    href: "https://github.com/ky1ejs/Jim"
+  - kind: "Repo"
+    title: "claude-plugins"
+    desc: "My personal Claude Code plugin marketplace."
+    href: "https://github.com/ky1ejs/claude-plugins"
+---

--- a/src/content/areas/coffee.md
+++ b/src/content/areas/coffee.md
@@ -1,0 +1,31 @@
+---
+title: "Coffee"
+mark: coffee
+order: 5
+display: band
+meta: "Linea Micra"
+why: "It started because I lived with a Neapolitan in London. It has since cost me a great deal of money and produced four repositories."
+chain:
+  - label: "bought a Micra"
+  - label: "lm-mods.fyi"
+    code: true
+  - label: "controller"
+    code: true
+  - label: "Dialed In"
+    code: true
+media:
+  layout: side
+  images:
+    - alt: "The espresso machine"
+      label: "Photo — the machine"
+      # src: /areas/coffee-1.jpg
+items:
+  - kind: "Site"
+    title: "lm-mods.fyi"
+    desc: "Every Linea Micra mod, catalogued in one place."
+    href: "https://lm-mods.fyi"
+  - kind: "Repo"
+    title: "ShotStopper"
+    desc: "iOS companion for the brew-by-weight device."
+    href: "https://github.com/ky1ejs/ShotStopper"
+---

--- a/src/content/areas/electronics.md
+++ b/src/content/areas/electronics.md
@@ -1,0 +1,26 @@
+---
+title: "Electronics"
+mark: chip
+order: 3
+display: band
+meta: "ESP32"
+why: "Mostly ESP32 — LiPo charging, rotary encoders, and the network and cameras that run the house."
+chain:
+  - label: "wanted a knob"
+  - label: "rotary-encoder-esp32"
+    code: true
+  - label: "linea-micra-controller"
+    code: true
+media:
+  layout: grid
+  images: []
+items:
+  - kind: "Repo"
+    title: "rotary-encoder-esp32"
+    desc: "Detent filtering and multi-encoder support."
+    href: "https://github.com/ky1ejs/rotary-encoder-esp32"
+  - kind: "Repo"
+    title: "homelab"
+    desc: "Infrastructure and automation, in Go."
+    href: "https://github.com/ky1ejs/homelab"
+---

--- a/src/content/areas/fishing.md
+++ b/src/content/areas/fishing.md
@@ -1,0 +1,11 @@
+---
+title: "Fishing"
+mark: fish
+order: 7
+display: compact
+why: "Fly, upstate and out west. The one hobby that hasn't turned into a repo. Yet."
+media:
+  layout: grid
+  images: []
+items: []
+---

--- a/src/content/areas/keyboards.md
+++ b/src/content/areas/keyboards.md
@@ -1,0 +1,21 @@
+---
+title: "Keyboards"
+mark: keyboard
+order: 4
+display: band
+meta: "Split · ergo"
+why: "A Dactyl and its siblings, remapped more often than is reasonable."
+media:
+  layout: side
+  images:
+    - alt: "My keyboard"
+      label: "Photo — the board"
+      # src: /areas/keyboards-1.jpg
+items:
+  - kind: "Repo"
+    title: "kylejs-zmk-configs"
+    desc: "My keymaps for ZMK."
+    href: "https://github.com/ky1ejs/kylejs-zmk-configs"
+  - kind: "Print"
+    title: "Skadis keyboard mount"
+---

--- a/src/content/areas/outdoors.md
+++ b/src/content/areas/outdoors.md
@@ -1,0 +1,12 @@
+---
+title: "Travel, nature & hiking"
+mark: mountain
+railLabel: "Outdoors"
+order: 8
+display: compact
+why: "Usually with a rod in the car."
+media:
+  layout: grid
+  images: []
+items: []
+---

--- a/src/content/areas/photography.md
+++ b/src/content/areas/photography.md
@@ -1,0 +1,12 @@
+---
+title: "Photography"
+mark: camera
+railLabel: "Photos"
+order: 6
+display: compact
+why: "Street, mostly. Landscape when I leave the city."
+media:
+  layout: grid
+  images: []
+items: []
+---

--- a/src/content/areas/strength-training.md
+++ b/src/content/areas/strength-training.md
@@ -1,0 +1,12 @@
+---
+title: "Strength training"
+mark: weight
+railLabel: "Training"
+order: 9
+display: compact
+why: "Ten kilos down over six months, and a lot learned doing it."
+media:
+  layout: grid
+  images: []
+items: []
+---

--- a/src/content/projects/bugger.md
+++ b/src/content/projects/bugger.md
@@ -1,0 +1,8 @@
+---
+title: "Bugger"
+description: "Screenshot annotation for bug and feedback reporting on iOS."
+group: tools
+repo: ky1ejs/Bugger
+status: shipped
+order: 50
+---

--- a/src/content/projects/byte.md
+++ b/src/content/projects/byte.md
@@ -1,0 +1,8 @@
+---
+title: "Byte"
+description: "Nutrition planning and shopping list generation."
+group: apps
+repo: ky1ejs/Byte-iOS
+status: archived
+order: 50
+---

--- a/src/content/projects/check-diff-paths-action.md
+++ b/src/content/projects/check-diff-paths-action.md
@@ -1,0 +1,8 @@
+---
+title: "check-diff-paths-action"
+description: "A GitHub Action for checking whether given paths changed."
+group: tools
+repo: ky1ejs/check-diff-paths-action
+status: shipped
+order: 70
+---

--- a/src/content/projects/claude-plugins.md
+++ b/src/content/projects/claude-plugins.md
@@ -1,0 +1,9 @@
+---
+title: "claude-plugins"
+description: "My personal Claude Code plugin marketplace."
+group: tools
+repo: ky1ejs/claude-plugins
+status: active
+featured: true
+order: 10
+---

--- a/src/content/projects/cut.md
+++ b/src/content/projects/cut.md
@@ -1,0 +1,11 @@
+---
+title: "Cut"
+description: "An app for viewing the latest movies, remembering the ones you love and the ones you want to see."
+group: apps
+repo: ky1ejs/cut-ios
+status: active
+featured: true
+order: 20
+---
+
+A Swift client on top of a Ruby API ([cut-api](https://github.com/ky1ejs/cut-api)) and a notifications worker. It's also where I try out AI workflows without stakeholders to answer to.

--- a/src/content/projects/esp32-setups.md
+++ b/src/content/projects/esp32-setups.md
@@ -1,0 +1,8 @@
+---
+title: "esp32-setups"
+description: "A set of setups that work with ESP32, to check hardware is configured properly before building on it."
+group: workshop
+repo: ky1ejs/esp32-setups
+status: shipped
+order: 30
+---

--- a/src/content/projects/homelab.md
+++ b/src/content/projects/homelab.md
@@ -1,0 +1,8 @@
+---
+title: "Home lab"
+description: "Infrastructure and automation for the home lab, written in Go."
+group: workshop
+repo: ky1ejs/homelab
+status: active
+order: 10
+---

--- a/src/content/projects/jim.md
+++ b/src/content/projects/jim.md
@@ -1,0 +1,9 @@
+---
+title: "Jim"
+description: "An iOS app for tracking your gym workouts."
+group: apps
+repo: ky1ejs/Jim
+status: shipped
+featured: true
+order: 10
+---

--- a/src/content/projects/linea-micra-controller.md
+++ b/src/content/projects/linea-micra-controller.md
@@ -1,0 +1,8 @@
+---
+title: "Linea Micra controller"
+description: "An ESP32-based hardware controller for the Linea Micra."
+group: espresso
+repo: ky1ejs/linea-micra-controller
+status: experiment
+order: 20
+---

--- a/src/content/projects/lm-mods.md
+++ b/src/content/projects/lm-mods.md
@@ -1,0 +1,12 @@
+---
+title: "lm-mods.fyi"
+description: "A catalogue of the community and commercial mods available for the La Marzocco Linea Micra."
+group: espresso
+repo: ky1ejs/linea-micra-mods
+url: https://lm-mods.fyi
+status: active
+featured: true
+order: 10
+---
+
+Built because the good mods were scattered across forums, Reddit threads and Etsy listings, and I kept losing track of what I'd already found.

--- a/src/content/projects/macos-bootstrap.md
+++ b/src/content/projects/macos-bootstrap.md
@@ -1,0 +1,8 @@
+---
+title: "macOS bootstrap"
+description: "The configs, CLI programs and applications I put on every Mac."
+group: tools
+repo: ky1ejs/kylejs-macOS-bootstrap
+status: active
+order: 80
+---

--- a/src/content/projects/orca.md
+++ b/src/content/projects/orca.md
@@ -1,0 +1,8 @@
+---
+title: "orca"
+description: "Manage projects and agents in a single UI."
+group: tools
+repo: ky1ejs/orca
+status: experiment
+order: 40
+---

--- a/src/content/projects/parasol.md
+++ b/src/content/projects/parasol.md
@@ -1,0 +1,8 @@
+---
+title: "Parasol"
+description: "Reformats the Coverage.profdata file Xcode generates, for use by humans and CI."
+group: tools
+repo: ky1ejs/Parasol
+status: archived
+order: 20
+---

--- a/src/content/projects/printer-profiles.md
+++ b/src/content/projects/printer-profiles.md
@@ -1,0 +1,8 @@
+---
+title: "3D printer profiles"
+description: "My 3D printing profiles."
+group: workshop
+repo: ky1ejs/3d-printer-profiles
+status: active
+order: 20
+---

--- a/src/content/projects/release-notes-action.md
+++ b/src/content/projects/release-notes-action.md
@@ -1,0 +1,8 @@
+---
+title: "release-notes-action"
+description: "A GitHub Action that generates release notes from commits, PRs and issues."
+group: tools
+repo: ky1ejs/release-notes-action
+status: shipped
+order: 60
+---

--- a/src/content/projects/rotary-encoder-esp32.md
+++ b/src/content/projects/rotary-encoder-esp32.md
@@ -1,0 +1,10 @@
+---
+title: "rotary-encoder-esp32"
+description: "A high-performance rotary encoder library for ESP32, with detent filtering and multi-encoder support."
+group: espresso
+repo: ky1ejs/rotary-encoder-esp32
+status: shipped
+order: 30
+---
+
+Fell out of building the Micra controller — the encoder handling was the fiddliest part, so it became its own library.

--- a/src/content/projects/shotstopper.md
+++ b/src/content/projects/shotstopper.md
@@ -1,0 +1,8 @@
+---
+title: "ShotStopper"
+description: "An iOS companion app for the shotStopper brew-by-weight device."
+group: espresso
+repo: ky1ejs/ShotStopper
+status: active
+order: 40
+---

--- a/src/content/projects/splitty.md
+++ b/src/content/projects/splitty.md
@@ -1,0 +1,8 @@
+---
+title: "splitty"
+description: "A Splitwise alternative, written in Go."
+group: apps
+repo: ky1ejs/splitty
+status: experiment
+order: 30
+---

--- a/src/content/projects/stargate.md
+++ b/src/content/projects/stargate.md
@@ -1,0 +1,8 @@
+---
+title: "Stargate"
+description: "Simple, Swift deeplinking and notification handling."
+group: tools
+repo: ky1ejs/Stargate
+status: archived
+order: 30
+---

--- a/src/content/projects/step-widget.md
+++ b/src/content/projects/step-widget.md
@@ -1,0 +1,8 @@
+---
+title: "step-widget"
+description: "iOS home and lock screen widgets that show your live step count."
+group: apps
+repo: ky1ejs/step-widget
+status: shipped
+order: 40
+---

--- a/src/content/projects/zmk-configs.md
+++ b/src/content/projects/zmk-configs.md
@@ -1,0 +1,8 @@
+---
+title: "ZMK keymaps"
+description: "My keymaps for ZMK."
+group: keyboards
+repo: ky1ejs/kylejs-zmk-configs
+status: active
+order: 10
+---

--- a/src/layouts/Site.astro
+++ b/src/layouts/Site.astro
@@ -25,6 +25,7 @@ const props = Astro.props;
       </div>
       <div class="flex items-center gap-4">
         <a class="text-lg" href="/about">About</a>
+        <a class="text-lg" href="/projects">Projects</a>
         <a class="text-lg" href="/posts">Posts</a>
         <ThemeButton />
       </div>
@@ -38,6 +39,7 @@ const props = Astro.props;
       <hr class="border-muted mb-3 border-t-[0.5px]" />
       <div class="flex justify-center gap-4">
         <a href="/about">About</a>
+        <a href="/projects">Projects</a>
         <a href="/posts">Posts</a>
       </div>
       <Copyright />

--- a/src/lib/area-marks.ts
+++ b/src/lib/area-marks.ts
@@ -1,0 +1,38 @@
+/**
+ * Line-art marks, one per area, plus the pen used to tag writing.
+ *
+ * Drawn from Kyle's tattoo reference: uniform stroke, no fill, no shading, and a
+ * specific object rather than an abstract glyph (a portafilter, not a coffee cup).
+ * Rendered by AreaMark.astro, which inherits `color` so they take the accent in
+ * either theme.
+ */
+export type MarkName =
+  | "code"
+  | "printer"
+  | "chip"
+  | "keyboard"
+  | "coffee"
+  | "camera"
+  | "fish"
+  | "mountain"
+  | "weight"
+  | "pen";
+
+export const markPaths: Record<MarkName, string> = {
+  code: '<path d="M11 13h42v29H11z"/><path d="M5 50h54l-5-8H10z"/><path d="M26 47h12"/><path d="M23 23l-6 5 6 5"/><path d="M41 23l6 5-6 5"/><path d="M36 21l-8 14"/>',
+  printer:
+    '<path d="M8 9v45M56 9v45"/><path d="M8 9h48"/><path d="M8 21h48"/><path d="M31 21v6"/><path d="M27 27h9l-4 6z"/><path d="M11 49h42"/><path d="M23 49c0-11 3-16 9-16s9 5 9 16"/><path d="M24 43h16M23 46h18"/>',
+  chip: '<path d="M15 13h34v38H15z"/><path d="M26 6h12v7H26z"/><path d="M25 25h14v13H25z"/><path d="M19 19h4M19 24h4M19 29h4M19 34h4M41 19h4M41 24h4M41 29h4M41 34h4"/><path d="M22 44h8M35 44c6 0 8 4 8 8"/><circle cx="43" cy="55" r="2"/>',
+  keyboard:
+    '<path d="M4 28l22-5v15L4 43z"/><path d="M60 28l-22-5v15l22 5z"/><path d="M26 33c4 7 8 7 12 0"/><path d="M9 30l14-3M9 35l14-3M55 30l-14-3M55 35l-14-3"/>',
+  coffee:
+    '<ellipse cx="25" cy="18" rx="16" ry="5.5"/><path d="M9 18c0 9 2 15 5 19h22c3-4 5-10 5-19"/><path d="M19 37l-1 10h5l-1-10"/><path d="M31 37l1 10h-5l1-10"/><path d="M41 18l17 4v6l-16-4"/><path d="M46 20.5l-1 6M51 22l-1 6"/>',
+  camera:
+    '<path d="M6 19h11l4-6h20l4 6h13v30H6z"/><circle cx="32" cy="34" r="11"/><circle cx="32" cy="34" r="5.5"/><circle cx="50" cy="25" r="1.6"/><path d="M11 24h6"/>',
+  fish: '<path d="M5 36c9-14 29-14 38 0-9 14-29 14-38 0z"/><path d="M43 36l14-9v18z"/><circle cx="15" cy="31" r="1.7"/><path d="M20 25c4-5 10-6 15-3"/><path d="M22 46c4 4 9 4 13 1"/><path d="M12 36h5M24 32h4M30 40h4"/>',
+  mountain:
+    '<path d="M3 50l17-27 9 14 7-10 25 23z"/><path d="M14 39l6 5M32 33l5 6"/><path d="M50 50v-7"/><path d="M45 45l5-6 5 6M46 40l4-5 4 5"/><circle cx="48" cy="15" r="5"/>',
+  weight:
+    '<path d="M4 25v14M9 19v26M55 19v26M60 25v14"/><path d="M9 32h46"/><path d="M15 27v10M49 27v10"/><path d="M24 29h16M24 35h16"/>',
+  pen: '<path d="M45 8l9 9-30 30-12 3 3-12z"/><path d="M40 13l9 9"/><path d="M12 50l4 4"/><path d="M8 58h48"/>',
+};

--- a/src/lib/project-groups.ts
+++ b/src/lib/project-groups.ts
@@ -1,0 +1,45 @@
+export type ProjectGroupId =
+  | "espresso"
+  | "apps"
+  | "tools"
+  | "keyboards"
+  | "workshop";
+
+export interface ProjectGroup {
+  id: ProjectGroupId;
+  title: string;
+  /** One or two lines setting up why this group of projects exists. */
+  blurb: string;
+}
+
+/** Order here is the order they appear on /projects. */
+export const projectGroups: ProjectGroup[] = [
+  {
+    id: "espresso",
+    title: "Espresso",
+    blurb:
+      "A coffee habit that got out of hand. It started with picking a machine, and ended with me writing firmware for it.",
+  },
+  {
+    id: "apps",
+    title: "Apps",
+    blurb:
+      "Things I've shipped, and things I started and haven't finished. Mostly iOS, increasingly not.",
+  },
+  {
+    id: "tools",
+    title: "Developer tools",
+    blurb:
+      "Small things built to make my own work better. A few of them turned out to make other people's better too.",
+  },
+  {
+    id: "keyboards",
+    title: "Keyboards",
+    blurb: "Split, ergonomic, and endlessly re-mapped.",
+  },
+  {
+    id: "workshop",
+    title: "Home lab & workshop",
+    blurb: "The house, the printer, and the microcontrollers in between.",
+  },
+];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,8 +2,13 @@
 import Base from "../layouts/Base.astro";
 import Copyright from "../components/Copyright.astro";
 import ThemeButton from "../components/ThemeButton.astro";
+import { getCollection } from "astro:content";
 import { Image } from "astro:assets";
 import meImage from "../../public/me.jpg";
+
+const featured = (await getCollection("projects"))
+  .filter((p) => p.data.featured)
+  .sort((a, b) => a.data.order - b.data.order);
 ---
 
 <Base>
@@ -12,8 +17,8 @@ import meImage from "../../public/me.jpg";
     <ThemeButton position="bottom" />
   </div>
 
-  <div class="mt-16 flex items-center justify-center sm:absolute sm:top-0 sm:right-0 sm:bottom-0 sm:left-0 sm:m-auto sm:mt-0">
-    <div class="w-[85%] text-center sm:w-fit">
+  <div class="mt-16 flex items-center justify-center sm:mt-24 sm:mb-16">
+    <div class="w-[85%] text-center sm:w-[26rem]">
       <div class="background-and-shadow bg-background-secondary rounded-xl border-b-2 border-gray-300 px-6 pt-8 pb-6 shadow-lg dark:border-none dark:shadow-none">
         <div class="fade-in three mx-auto mb-4 h-36 w-36 overflow-hidden rounded-full">
           <Image
@@ -54,6 +59,31 @@ import meImage from "../../public/me.jpg";
           </div>
         </div>
       </div>
+      {featured.length > 0 && (
+        <div class="bg-background-secondary mt-4 rounded-xl px-5 py-4 text-left">
+          <div class="mb-2 flex items-baseline justify-between">
+            <span class="text-muted text-xs tracking-widest uppercase">
+              Things I've built
+            </span>
+            <a class="text-sm no-underline hover:underline" href="/projects">
+              All projects &rarr;
+            </a>
+          </div>
+          <ul class="m-0 list-none p-0">
+            {featured.map((p) => (
+              <li class="border-muted/25 border-b py-2 last:border-b-0">
+                <a class="font-semibold no-underline hover:underline" href="/projects">
+                  {p.data.title}
+                </a>
+                <div class="text-muted text-sm leading-snug">
+                  {p.data.description}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       <div class="my-4 text-center text-gray-500">
         I sometimes blog{" "}
         <a class="hover:text-primary underline" href="/posts">here</a>{" "}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,146 +2,105 @@
 import Base from "../layouts/Base.astro";
 import Copyright from "../components/Copyright.astro";
 import ThemeButton from "../components/ThemeButton.astro";
+import AreaMark from "../components/AreaMark.astro";
+import AreaBand from "../components/AreaBand.astro";
+import AreaCompact from "../components/AreaCompact.astro";
 import { getCollection } from "astro:content";
 import { Image } from "astro:assets";
 import meImage from "../../public/me.jpg";
 
-const featured = (await getCollection("projects"))
-  .filter((p) => p.data.featured)
-  .sort((a, b) => a.data.order - b.data.order);
+const areas = (await getCollection("areas")).sort(
+  (a, b) => a.data.order - b.data.order
+);
+
+const bands = areas.filter((a) => a.data.display === "band");
+const compact = areas.filter((a) => a.data.display === "compact");
+
+const socials = [
+  { href: "https://github.com/ky1ejs", label: "GitHub" },
+  { href: "https://www.linkedin.com/in/kylejs/", label: "LinkedIn" },
+  { href: "https://www.threads.net/@_kylejs_", label: "Threads" },
+  { href: "https://instagram.com/_kylejs_", label: "Instagram" },
+  { href: "https://open.spotify.com/user/kylejm_", label: "Spotify" },
+];
 ---
 
-<Base>
-  {/* Home theme button - fixed position */}
-  <div id="home-theme-btn" class="fixed right-4 top-4 z-[1000] flex justify-end">
+<Base
+  description="Kyle Satti — product engineer in NYC. Writing, side projects, 3D printing, electronics, coffee and the rest of it."
+>
+  <div class="fixed top-4 right-4 z-[1000]">
     <ThemeButton position="bottom" />
   </div>
 
-  <div class="mt-16 flex items-center justify-center sm:mt-24 sm:mb-16">
-    <div class="w-[85%] text-center sm:w-[26rem]">
-      <div class="background-and-shadow bg-background-secondary rounded-xl border-b-2 border-gray-300 px-6 pt-8 pb-6 shadow-lg dark:border-none dark:shadow-none">
-        <div class="fade-in three mx-auto mb-4 h-36 w-36 overflow-hidden rounded-full">
-          <Image
-            src={meImage}
-            alt="Headshot of Kyle Satti"
-            width={288}
-            height={288}
-            loading="eager"
-          />
-        </div>
-        <div class="rise-up mb-2">
-          <div class="text-primary text-3xl font-bold">Kyle Satti</div>
-          <div class="text-secondary text-xl">kylejs</div>
-        </div>
-        <div class="fade-in two pb-10">
-          I like to build teams and create things, <br /> mostly with an
-          IDE, camera or 3D printer.
-        </div>
-        <div class="fade-in three flex items-center justify-center gap-4 pb-4">
-          <a href="https://github.com/ky1ejs">
-            <svg class="fill-secondary h-10 w-10 hover:fill-[#333]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50"><path d="M17.791,46.836C18.502,46.53,19,45.823,19,45v-5.4c0-0.197,0.016-0.402,0.041-0.61C19.027,38.994,19.014,38.997,19,39 c0,0-3,0-3.6,0c-1.5,0-2.8-0.6-3.4-1.8c-0.7-1.3-1-3.5-2.8-4.7C8.9,32.3,9.1,32,9.7,32c0.6,0.1,1.9,0.9,2.7,2c0.9,1.1,1.8,2,3.4,2 c2.487,0,3.82-0.125,4.622-0.555C21.356,34.056,22.649,33,24,33v-0.025c-5.668-0.182-9.289-2.066-10.975-4.975 c-3.665,0.042-6.856,0.405-8.677,0.707c-0.058-0.327-0.108-0.656-0.151-0.987c1.797-0.296,4.843-0.647,8.345-0.714 c-0.112-0.276-0.209-0.559-0.291-0.849c-3.511-0.178-6.541-0.039-8.187,0.097c-0.02-0.332-0.047-0.663-0.051-0.999 c1.649-0.135,4.597-0.27,8.018-0.111c-0.079-0.5-0.13-1.011-0.13-1.543c0-1.7,0.6-3.5,1.7-5c-0.5-1.7-1.2-5.3,0.2-6.6 c2.7,0,4.6,1.3,5.5,2.1C21,13.4,22.9,13,25,13s4,0.4,5.6,1.1c0.9-0.8,2.8-2.1,5.5-2.1c1.5,1.4,0.7,5,0.2,6.6c1.1,1.5,1.7,3.2,1.6,5 c0,0.484-0.045,0.951-0.11,1.409c3.499-0.172,6.527-0.034,8.204,0.102c-0.002,0.337-0.033,0.666-0.051,0.999 c-1.671-0.138-4.775-0.28-8.359-0.089c-0.089,0.336-0.197,0.663-0.325,0.98c3.546,0.046,6.665,0.389,8.548,0.689 c-0.043,0.332-0.093,0.661-0.151,0.987c-1.912-0.306-5.171-0.664-8.879-0.682C35.112,30.873,31.557,32.75,26,32.969V33 c2.6,0,5,3.9,5,6.6V45c0,0.823,0.498,1.53,1.209,1.836C41.37,43.804,48,35.164,48,25C48,12.318,37.683,2,25,2S2,12.318,2,25 C2,35.164,8.63,43.804,17.791,46.836z"/></svg>
-          </a>
-          <a href="https://open.spotify.com/user/kylejm_">
-            <svg class="fill-secondary h-10 w-10 hover:fill-[#1db954]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50"><path d="M25.009,1.982C12.322,1.982,2,12.304,2,24.991S12.322,48,25.009,48s23.009-10.321,23.009-23.009S37.696,1.982,25.009,1.982z M34.748,35.333c-0.289,0.434-0.765,0.668-1.25,0.668c-0.286,0-0.575-0.081-0.831-0.252C30.194,34.1,26,33,22.5,33.001 c-3.714,0.002-6.498,0.914-6.526,0.923c-0.784,0.266-1.635-0.162-1.897-0.948s0.163-1.636,0.949-1.897 c0.132-0.044,3.279-1.075,7.474-1.077C26,30,30.868,30.944,34.332,33.253C35.022,33.713,35.208,34.644,34.748,35.333z M37.74,29.193 c-0.325,0.522-0.886,0.809-1.459,0.809c-0.31,0-0.624-0.083-0.906-0.26c-4.484-2.794-9.092-3.385-13.062-3.35 c-4.482,0.04-8.066,0.895-8.127,0.913c-0.907,0.258-1.861-0.272-2.12-1.183c-0.259-0.913,0.272-1.862,1.184-2.12 c0.277-0.079,3.854-0.959,8.751-1c4.465-0.037,10.029,0.61,15.191,3.826C37.995,27.328,38.242,28.388,37.74,29.193z M40.725,22.013 C40.352,22.647,39.684,23,38.998,23c-0.344,0-0.692-0.089-1.011-0.275c-5.226-3.068-11.58-3.719-15.99-3.725 c-0.021,0-0.042,0-0.063,0c-5.333,0-9.44,0.938-9.481,0.948c-1.078,0.247-2.151-0.419-2.401-1.495 c-0.25-1.075,0.417-2.149,1.492-2.4C11.729,16.01,16.117,15,21.934,15c0.023,0,0.046,0,0.069,0 c4.905,0.007,12.011,0.753,18.01,4.275C40.965,19.835,41.284,21.061,40.725,22.013z"/></svg>
-          </a>
-          <a href="https://www.linkedin.com/in/kylejs/">
-            <svg class="fill-secondary h-10 w-10 hover:fill-[#0077b5]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50"><path d="M25,2C12.318,2,2,12.317,2,25s10.318,23,23,23s23-10.317,23-23S37.682,2,25,2z M18,35h-4V20h4V35z M16,17 c-1.105,0-2-0.895-2-2c0-1.105,0.895-2,2-2s2,0.895,2,2C18,16.105,17.105,17,16,17z M37,35h-4v-5v-2.5c0-1.925-1.575-3.5-3.5-3.5 S26,25.575,26,27.5V35h-4V20h4v1.816C27.168,20.694,28.752,20,30.5,20c3.59,0,6.5,2.91,6.5,6.5V35z"/></svg>
-          </a>
-          <a href="https://instagram.com/_kylejs_">
-            <svg class="fill-secondary h-10 w-10 hover:fill-[#e1306c]" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50"><path d="M 16 3 C 8.83 3 3 8.83 3 16 L 3 34 C 3 41.17 8.83 47 16 47 L 34 47 C 41.17 47 47 41.17 47 34 L 47 16 C 47 8.83 41.17 3 34 3 L 16 3 z M 37 11 C 38.1 11 39 11.9 39 13 C 39 14.1 38.1 15 37 15 C 35.9 15 35 14.1 35 13 C 35 11.9 35.9 11 37 11 z M 25 14 C 31.07 14 36 18.93 36 25 C 36 31.07 31.07 36 25 36 C 18.93 36 14 31.07 14 25 C 14 18.93 18.93 14 25 14 z M 25 16 C 20.04 16 16 20.04 16 25 C 16 29.96 20.04 34 25 34 C 29.96 34 34 29.96 34 25 C 34 20.04 29.96 16 25 16 z"/></svg>
-          </a>
-          {/* Threads */}
-          <div class="relative h-[36px] w-[36px]">
-            <a href="https://www.threads.net/@_kylejs_">
-              <svg class="fill-secondary" aria-label="Threads" viewBox="0 0 192 192" xmlns="http://www.w3.org/2000/svg"><path d="M141.537 88.9883C140.71 88.5919 139.87 88.2104 139.019 87.8451C137.537 60.5382 122.616 44.905 97.5619 44.745C97.4484 44.7443 97.3355 44.7443 97.222 44.7443C82.2364 44.7443 69.7731 51.1409 62.102 62.7807L75.881 72.2328C81.6116 63.5383 90.6052 61.6848 97.2286 61.6848C97.3051 61.6848 97.3819 61.6848 97.4576 61.6855C105.707 61.7381 111.932 64.1366 115.961 68.814C118.893 72.2193 120.854 76.925 121.825 82.8638C114.511 81.6207 106.601 81.2385 98.145 81.7233C74.3247 83.0954 59.0111 96.9879 60.0396 116.292C60.5615 126.084 65.4397 134.508 73.775 140.011C80.8224 144.663 89.899 146.938 99.3323 146.423C111.79 145.74 121.563 140.987 128.381 132.296C133.559 125.696 136.834 117.143 138.28 106.366C144.217 109.949 148.617 114.664 151.047 120.332C155.179 129.967 155.42 145.8 142.501 158.708C131.182 170.016 117.576 174.908 97.0135 175.059C74.2042 174.89 56.9538 167.575 45.7381 153.317C35.2355 139.966 29.8077 120.682 29.6052 96C29.8077 71.3178 35.2355 52.0336 45.7381 38.6827C56.9538 24.4249 74.2039 17.11 97.0132 16.9405C119.988 17.1113 137.539 24.4614 149.184 38.788C154.894 45.8136 159.199 54.6488 162.037 64.9503L178.184 60.6422C174.744 47.9622 169.331 37.0357 161.965 27.974C147.036 9.60668 125.202 0.195148 97.0695 0H96.9569C68.8816 0.19447 47.2921 9.6418 32.7883 28.0793C19.8819 44.4864 13.2244 67.3157 13.0007 95.9325L13 96L13.0007 96.0675C13.2244 124.684 19.8819 147.514 32.7883 163.921C47.2921 182.358 68.8816 191.806 96.9569 192H97.0695C122.03 191.827 139.624 185.292 154.118 170.811C173.081 151.866 172.51 128.119 166.26 113.541C161.776 103.087 153.227 94.5962 141.537 88.9883ZM98.4405 129.507C88.0005 130.095 77.1544 125.409 76.6196 115.372C76.2232 107.93 81.9158 99.626 99.0812 98.6368C101.047 98.5234 102.976 98.468 104.871 98.468C111.106 98.468 116.939 99.0737 122.242 100.233C120.264 124.935 108.662 128.946 98.4405 129.507Z"></path></svg>
-              <svg class="absolute top-0 left-0 h-full w-full opacity-0 hover:opacity-100" viewBox="0 0 153.14 178" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient id="threads-grad" x1="41.76" y1="-17.79" x2="110.1" y2="180.87" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#515bd4"/><stop offset="0.25" stop-color="#8134af"/><stop offset="0.5" stop-color="#dd2a7b"/><stop offset="0.75" stop-color="#f58529"/><stop offset="1" stop-color="#feda77"/></linearGradient></defs><path fill="url(#threads-grad)" d="M119.16,82.5c-.76-.37-1.54-.72-2.33-1.06-1.37-25.32-15.21-39.81-38.43-40h-.32c-13.89,0-25.45,5.93-32.56,16.72L58.3,67c5.31-8.06,13.65-9.78,19.79-9.78h.21c7.65.05,13.42,2.27,17.15,6.61,2.72,3.15,4.54,7.52,5.44,13a97.8,97.8,0,0,0-22-1.06C56.85,77,42.66,89.92,43.61,107.81a27.6,27.6,0,0,0,12.73,22A39.4,39.4,0,0,0,80,135.75c11.55-.64,20.61-5,26.93-13.1,4.8-6.12,7.83-14.05,9.17-24a28.29,28.29,0,0,1,11.84,13c3.83,8.93,4.06,23.61-7.92,35.58-10.49,10.48-23.11,15-42.17,15.15-21.15-.15-37.14-6.93-47.54-20.15C20.61,129.76,15.58,111.88,15.4,89c.18-22.88,5.21-40.76,15-53.14,10.4-13.22,26.39-20,47.54-20.15,21.3.15,37.57,7,48.36,20.25,5.3,6.51,9.29,14.7,11.92,24.25l15-4a81.07,81.07,0,0,0-15-30.29C124.26,8.91,104-.18,77.94,0h-.1c-26,.18-46.05,8.94-59.49,26C6.38,41.24.21,62.41,0,88.94v.12c.21,26.53,6.38,47.7,18.35,62.91,13.44,17.09,33.46,25.85,59.49,26h.1c23.14-.16,39.45-6.22,52.89-19.64,17.58-17.57,17-39.58,11.25-53.1C137.93,95.57,130,87.7,119.16,82.5M79.21,120.06c-9.68.55-19.73-3.8-20.23-13.1-.37-6.9,4.91-14.6,20.83-15.52,1.82-.1,3.61-.15,5.36-.15a76,76,0,0,1,16.11,1.63c-1.84,22.91-12.59,26.62-22.07,27.14"/></svg>
-            </a>
-          </div>
-        </div>
+  {/* Hero */}
+  <header class="mx-auto max-w-[800px] px-6 pt-16 pb-8 sm:px-8">
+    <div class="mb-5 flex items-center gap-3">
+      <div class="h-12 w-12 shrink-0 overflow-hidden rounded-full">
+        <Image src={meImage} alt="Headshot of Kyle Satti" width={96} height={96} loading="eager" />
       </div>
-      {featured.length > 0 && (
-        <div class="bg-background-secondary mt-4 rounded-xl px-5 py-4 text-left">
-          <div class="mb-2 flex items-baseline justify-between">
-            <span class="text-muted text-xs tracking-widest uppercase">
-              Things I've built
-            </span>
-            <a class="text-sm no-underline hover:underline" href="/projects">
-              All projects &rarr;
-            </a>
-          </div>
-          <ul class="m-0 list-none p-0">
-            {featured.map((p) => (
-              <li class="border-muted/25 border-b py-2 last:border-b-0">
-                <a class="font-semibold no-underline hover:underline" href="/projects">
-                  {p.data.title}
-                </a>
-                <div class="text-muted text-sm leading-snug">
-                  {p.data.description}
-                </div>
-              </li>
-            ))}
-          </ul>
+      <div>
+        <div class="font-semibold">Kyle Satti</div>
+        <div class="text-muted text-xs tracking-widest uppercase">
+          Senior Engineer &middot; Spotify &middot; NYC
         </div>
-      )}
-
-      <div class="my-4 text-center text-gray-500">
-        I sometimes blog{" "}
-        <a class="hover:text-primary underline" href="/posts">here</a>{" "}
-        &#x270D;&#xFE0F;
-        <div>
-          <p class="wave-label">
-            <a href="/about">About me</a>
-            {" "}<span class="hand text-lg">&#x1F44B;&#x1F3FC;</span>
-          </p>
-        </div>
-        <Copyright />
       </div>
     </div>
-  </div>
-</Base>
 
-<script>
-  function initHomeThemeButton() {
-    const btn = document.getElementById("home-theme-btn");
-    if (!btn) return;
+    <h1 class="mt-0 mb-3 text-[2rem] leading-[1.1] font-extrabold tracking-tight text-balance sm:text-5xl">
+      I build teams and make things &mdash; with an IDE, a camera and a 3D printer.
+    </h1>
 
-    function updatePosition() {
-      const isMobile = window.innerWidth < 500;
-      btn!.className = `fixed right-4 z-[1000] flex justify-end ${isMobile ? "bottom-4" : "top-4"}`;
+    <p class="text-muted m-0 max-w-[46ch]">
+      Ten years in product engineering. Everything below is something I actually do,
+      roughly in the order it takes up my life.
+    </p>
 
-      const popover = document.getElementById("theme-popover");
-      if (!popover) return;
-      if (isMobile) {
-        popover.classList.remove("top-10");
-        popover.classList.add("bottom-12");
-      } else {
-        popover.classList.remove("bottom-12");
-        popover.classList.add("top-10");
+    <div class="mt-4 flex flex-wrap gap-x-4 gap-y-1 text-sm">
+      {socials.map((s) => <a href={s.href}>{s.label}</a>)}
+    </div>
+  </header>
+
+  {/* Area rail */}
+  <nav
+    aria-label="Areas"
+    class="bg-background-primary border-muted/25 sticky top-0 z-[900] border-y"
+  >
+    <div class="mx-auto flex max-w-[800px] gap-1 overflow-x-auto px-6 py-2 sm:px-8">
+      {
+        areas.map((area) => (
+          <a
+            href={`#${area.id}`}
+            class="text-muted hover:text-primary flex shrink-0 flex-col items-center gap-1 rounded-lg px-2 py-1 no-underline"
+          >
+            <AreaMark name={area.data.mark} class="h-5 w-5" />
+            <span class="text-[9px] tracking-widest uppercase">
+              {area.data.railLabel ?? area.data.title}
+            </span>
+          </a>
+        ))
       }
-    }
+    </div>
+  </nav>
 
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
+  {bands.map((area, i) => <AreaBand area={area} alt={i % 2 === 0} />)}
+
+  {
+    compact.length > 0 && (
+      <div class="mx-auto grid max-w-[800px] gap-3 px-6 py-7 sm:grid-cols-2 sm:px-8">
+        {compact.map((area) => (
+          <AreaCompact area={area} />
+        ))}
+      </div>
+    )
   }
 
-  initHomeThemeButton();
-  document.addEventListener("astro:after-swap", initHomeThemeButton);
-</script>
-
-<style>
-  .wave-label:hover .hand {
-    animation-name: wave-animation;
-    animation-duration: 1.2s;
-    animation-iteration-count: infinite;
-    transform-origin: 70% 70%;
-    display: inline-block;
-  }
-
-  @keyframes wave-animation {
-    0% { transform: rotate(-2deg); }
-    25% { transform: rotate(14deg); }
-    50% { transform: rotate(-8deg); }
-    75% { transform: rotate(14deg); }
-    100% { transform: rotate(-2deg); }
-  }
-</style>
+  {/* Footer */}
+  <footer class="border-muted/25 mx-auto max-w-[800px] border-t px-6 py-8 text-center sm:px-8">
+    <div class="flex justify-center gap-4">
+      <a href="/posts">Writing</a>
+      <a href="/projects">Projects</a>
+      <a href="/about">About</a>
+    </div>
+    <Copyright />
+  </footer>
+</Base>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -1,0 +1,66 @@
+---
+import { getCollection, render } from "astro:content";
+import Site from "../../layouts/Site.astro";
+import ProjectCard from "../../components/ProjectCard.astro";
+import { projectGroups } from "../../lib/project-groups";
+
+const projects = await getCollection("projects");
+
+const rendered = await Promise.all(
+  projects.map(async (project) => ({
+    project,
+    // Body is optional — only render a note when there's something to say.
+    Content: project.body?.trim() ? (await render(project)).Content : undefined,
+  }))
+);
+
+const grouped = projectGroups
+  .map((group) => ({
+    group,
+    items: rendered
+      .filter(({ project }) => project.data.group === group.id)
+      .sort((a, b) => a.project.data.order - b.project.data.order),
+  }))
+  .filter(({ items }) => items.length > 0);
+---
+
+<Site
+  title="Projects | kylejs"
+  description="Side projects, tools and experiments by Kyle Satti — espresso hardware, iOS apps, developer tooling and a home lab."
+>
+  <div class="mt-4">
+    <h1>Projects</h1>
+    <p>
+      Most of these started as a rabbit hole I fell down and didn't climb back
+      out of. Almost everything here is on{" "}
+      <a href="https://github.com/ky1ejs" target="_blank" rel="noopener noreferrer">GitHub</a>.
+    </p>
+
+    {
+      grouped.map(({ group, items }) => (
+        <section class="mt-10">
+          <h2 id={group.id}>{group.title}</h2>
+          <p class="text-muted">{group.blurb}</p>
+          <div class="mt-3">
+            {items.map(({ project, Content }) => (
+              <ProjectCard
+                title={project.data.title}
+                description={project.data.description}
+                repo={project.data.repo}
+                url={project.data.url}
+                status={project.data.status}
+                year={project.data.year}
+              >
+                {Content && (
+                  <div class="text-muted mt-1 text-sm">
+                    <Content />
+                  </div>
+                )}
+              </ProjectCard>
+            ))}
+          </div>
+        </section>
+      ))
+    }
+  </div>
+</Site>


### PR DESCRIPTION
Gets the site standing so content and images can be edited directly. Implements the direction settled in #465: nine areas in Kyle's ranked order, writing threaded through them, line-art marks per area.

**Prototype:** https://claude.ai/code/artifact/73688e8b-ccdd-4f7c-ae0b-062b6b641e7b

## The important bit: layout is a content decision

You said the thing most likely to change the design is finding a really good image. So nothing about promoting an area or an image requires touching a component — it's all frontmatter in `src/content/areas/*.md`:

| Field | Does what |
| --- | --- |
| `display: band \| compact` | Promotes an area to a full-width band, or demotes it to a small card |
| `order` | Position on the page — your ranking |
| `media.layout: grid \| wide \| side \| hero` | How that area's images are arranged. **`hero` is the escape hatch** for a photo good enough to carry the whole section |
| `media.images[].src` | Omit it and you get a labelled placeholder. Add a path and the photo appears. |
| `railLabel` | Short name for the sticky rail |
| `items[].writing: true` | Tags an entry with the pen mark |

So "this photo is too good to be a thumbnail" is a two-line change: `display: band`, `media.layout: hero`.

## What's here

- **`areas` collection** — 9 files, one per area, with why-lines, chains, items and image slots
- **`AreaBand` / `AreaCompact` / `AreaMedia` / `AreaMark`** components
- **`src/lib/area-marks.ts`** — the 10 line-art marks as SVG path data
- **Home page rebuilt** — hero, sticky rail, 5 bands, 4 compact cards, footer
- **`/projects` page** from the earlier commit, unchanged — 21 curated projects

## Checks

- `pnpm build` passes, 10 pages
- Verified in **both themes** at 900px, and confirmed no horizontal overflow at 520px (`scrollWidth === clientWidth`)
- 5 image placeholders render where photos will go
- `pnpm lint` still crashes — **pre-existing on `main`** (`scopeManager.addGlobals is not a function`, ESLint 10.3.0), unrelated to this branch

## Over to you

- [ ] **Rewrite the why-lines.** Nine of them, one per area, in `src/content/areas/*.md`. Mine are drafted; the Coffee one is yours already.
- [ ] **Drop in photos.** Put them under `public/areas/` and set `src` on the slots. Four would lift it most: the machine, a print, the keyboard, one street shot.
- [ ] **Promote anything worth promoting** once you see the images in place.
- [ ] Cars is parked; the mark is drawn and reinstating it is one content file.

## Still open from earlier

- Vault-derived copy you may want to strike: the "29 designs" count, and the adventure-bike line (currently not on the site — it was in the prototype only).
- #462 / #463 / #464 remain unmerged and are independent of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)