### PR TITLE
fix: correct 6 typos across About page content

### DIFF
--- a/content/about/intro.md
+++ b/content/about/intro.md
@@ -1,4 +1,4 @@
 # Hello
-Hi, I'm Kyle, a nerd, product engineer, coder, photographer, coffee snob, watch collector, 3D printer, keyboard obssessor and team builder, living in NYC.
+Hi, I'm Kyle, a nerd, product engineer, coder, photographer, coffee snob, watch collector, 3D printer, keyboard obsessive and team builder, living in NYC.
 
 I've spent my 10+ year career working in the tech industry, building and leading teams, and creating software. 

--- a/content/about/personal.md
+++ b/content/about/personal.md
@@ -11,7 +11,7 @@ I spent my childhood in [Devizes, Wiltshire, UK](https://en.wikipedia.org/wiki/D
 ### Things I love
 * **Photography** – I usally go for street and landscape style
 * **3D Printing** – my hobby since COVID lockdown. I print several things a year and love designing my own models.
-* **Coffee** – I'm a bit of a coffee snob, thanks to living with a Neapoliton for a few years in London.
+* **Coffee** – I'm a bit of a coffee snob, thanks to living with a Neapolitan for a few years in London.
 * **Thoughtfully designed things** (e.g. watches or anything from Peak Design and Weber Workshops)
 * **Anyone passionate about something**, (usually) no matter what that something is. Biographies are one of my favorite genres of content for this reason.
 * **Coding** – I love making projects on the side but never finish them, like most engineers.

--- a/content/about/professional.mdx
+++ b/content/about/professional.mdx
@@ -1,4 +1,4 @@
-# Profesional
+# Professional
 ## Career in a (long) paragraph
 I started out as an iOS engineer after being inspired to make apps by my Apple fan boy era (which included working at the Genius Bar). After my first engineering job in publishing, I joined an ex-Apple Store colleague's start-up as his first hire. This start-up grew for a few years and so did my role, eventually transitioning me into leading product development. This product experience really left a mark on me; I see myself as a Product Engineer and love to be at the intersection of product, design and engineering. A short time after the start-up went bust, I joined Spotify to build Podcast features. Shortly after joining Spotify, my team's needs changed and prompted me to move into web and backend development. Although Spotify hired me as an iOS engineer, I've probably done a sum total of ~9 months of iOS dev since joining them in 2019. I mostly love this because the iOS toolchain and ecosystem is quite the PITA.
 
@@ -12,10 +12,10 @@ I've had the fortune of working across many of Spotify's organizations:
 1. **Core Experience** – working on podcast features in the mobile apps
 2. **Audiobooks** – building the initial Audiobook offering
 3. **Subscriptions** – focusing on converting users to Premium
-4. **Platform** (_present_) – today I work in Spotify's Producitvity Engineering org
+4. **Platform** (_present_) – today I work in Spotify's Productivity Engineering org
 
 My time at Spotify has often involved creating new teams. In the moves I've made above, I've rarely joined an established team, often having to work with a new group to set a new rhythm and way of working that matches our team's chemistry, problem space and the organization we sit within.
-## Tech I've worked with <strong className="font-bolt text-primary">a lot</strong>
+## Tech I've worked with <strong className="font-bold text-primary">a lot</strong>
 <PillCollection collections={[
   {titles: ["Swift", "Objective-C"], hex: "#F5A65B"},
   {titles: ["Java"], hex: "#C1CC99"},
@@ -24,10 +24,10 @@ My time at Spotify has often involved creating new teams. In the moves I've made
   {titles: ["Google Pubsub","Google CloudSQL", "Google BigTable", "Google BigQuery"], hex: "#55dbcb"},
 ]} />
 
-## Tech I've worked with <strong className="font-bolt text-primary">a fair bit</strong>
+## Tech I've worked with <strong className="font-bold text-primary">a fair bit</strong>
 <PillCollection collections={[{titles: ["Kubernetes", "Docker"], hex: "#E0BAD7"}]}/>
 
-## Tech I've worked with <strong className="font-bolt text-primary">a little</strong>
+## Tech I've worked with <strong className="font-bold text-primary">a little</strong>
 <PillCollection collections={[
   {titles: ["Kotlin"], hex: "#39a2ae"},
   {titles: ["Python"], hex: "#92b6b1"},

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -45,7 +45,7 @@ const personalHtml = await renderAboutContent("personal.md");
       {/* Selector */}
       <div class="selector">
         <input type="radio" name="bio" id="professional" checked />
-        <label class="font-bold" for="professional">Profesional</label>
+        <label class="font-bold" for="professional">Professional</label>
         <input type="radio" name="bio" id="personal" />
         <label class="font-bold" for="personal">Personal</label>
         <div class="indicator"></div>


### PR DESCRIPTION
## Summary

Fixed 6 typos across 4 files in the About page section:

| File | Line | Before | After |
|------|------|--------|-------|
| content/about/professional.mdx | 1 | # Profesional | # Professional |
| content/about/professional.mdx | 15 | Producitvity | Productivity |
| content/about/professional.mdx | 18,27,30 | font-bolt | font-bold |
| src/pages/about.astro | 48 | Profesional | Professional |
| content/about/intro.md | 2 | obssessor | obsessive |
| content/about/personal.md | 14 | Neapoliton | Neapolitan |

### Issues Fixed
- Fixes #463 (typos in About page copy)
- Fixes #462 (font-bolt typo)

---
*Submitted via PR攻关 (Jah-yee)*